### PR TITLE
Contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Sonata project contribution
+
+Thanks for you interest onto Sonata projects!
+
+Want to contribute? Please read the following documentation first:
+[dev-kit/doc/CONTRIBUTING.md](https://github.com/sonata-project/dev-kit/blob/master/doc/CONTRIBUTING.md).
+
+This is the only documentation you have to refer.

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -31,13 +31,20 @@ php-cs-fixer fix --verbose
 
 #### The content
 
-A Pull Request should concern one and **only one** subject.
+Ideally, a Pull Request should concern one and **only one** subject, so that it
+remains clear, and independant changes can be merged quickly.
 
-If you want to fix a typo and improve the performance of a process, you have to do two **separated** PR.
+If you want to fix a typo and improve the performance of a process, you should
+try as much as possible to it in a **separate** PR, so that we can quickly
+merge one while discussing the other.
 
 The goal is to have a clear commit history and make possible revert easier.
 
-If you found an issue/typo while writing your change that is not related to your work, please do another PR for that.
+If you found an issue/typo while writing your change that is not related to
+your work, please do another PR for that. In some rare cases, you might be
+forced to do it on the same PR. In this kind of situation, please add a comment
+on your PR explaining why you feel it is the case.
+
 
 #### The base branch
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -5,5 +5,52 @@ Thanks for you interest onto Sonata projects!
 ## Summary
 
 * [Issues]()
-* [Pull Request]()
+* [Pull Requests](#pull-requests)
 * [Label rules]()
+
+## Pull Requests
+
+All the sonata team will be glad to review your code changes propositions! :smile:
+
+But please, read the following before.
+
+### Coding style
+
+Each project follows [PSR-1](http://www.php-fig.org/psr/psr-1/), [PSR-2](http://www.php-fig.org/psr/psr-2/)
+and [Symfony Coding Standards](http://symfony.com/doc/current/contributing/code/standards.html) for coding style,
+[PSR-4](http://www.php-fig.org/psr/psr-4/) for autoloading.
+
+Please [install PHP Coding Standard Fixer](http://cs.sensiolabs.org/#installation)
+and run this command before committing your modifications:
+
+```bash
+php-cs-fixer fix --verbose
+```
+
+### Writing a Pull Requests
+
+#### The base branch
+
+Before writing a PR, you have to check on which branch your changes should be based.
+
+Each project follows [semver](http://semver.org/) convention for release management.
+
+Here is a short table resuming on which you have to start:
+
+Kind of modification | Backward Compatible (BC) | Type of release | Branch to target | Label |
+-------------------- | ------------------------ | --------------- | ---------------- | ----- |
+Bug fixes            | Yes                      | Patch           | `[latest].x`     | |
+Bug fixes            | No                       | Patch           | `master`         | |
+Feature              | Yes                      | Minor           | `[latest].x`     | |
+Feature              | No (Only if no choice)   | Major           | `master`         | |
+Deprecation          | Yes (Have to)            | Minor           | `[latest].x`     | |
+Deprecation removal  | No (Can't be)            | Major           | `master`         | |
+
+Notes:
+  * Branch `[latest].x` means the branch of the **latest stable** minor release (e.g. `3.x`).
+  Please refer to the branch list of the project and pick the **higher** one.
+  * If you PR is not **Backward Compatible** but can be, it **must** be:
+    * Changing a function/method signature? Prefer create a new one and deprecated the old one.
+    * Code deletion? Don't. Please deprecate it instead.
+    * If your BC PR is accepted, you can do a new one on the `master` branch which remove the deprecated code.
+    * SYMFONY DOC REF (same logic)?

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -27,7 +27,7 @@ and run this command before committing your modifications:
 php-cs-fixer fix --verbose
 ```
 
-### Writing a Pull Requests
+### Writing a Pull Request
 
 #### The content
 
@@ -72,26 +72,61 @@ If you are not sure of what to do, don't hesitate to open an issue about your PR
 
 #### The commit message
 
-The commit message has to be clear and related to the PR content.
+Sonata is a big project with many contributors, and a big part of the job is
+being able to understand the code at all times, be it when submitting a PR or
+looking at the history. Good commit messages are crucial to achieve this goal.
 
-The first line of the commit message must be short.
-The other lines must contains a complete description of what you done and why.
+There are already a few articles (or even single purpose websites) about this,
+we cannot recommend enough the following:
 
-The description is optional but recommended. It could be asked by the team if needed.
+* http://rakeroutes.com/blog/deliberate-git
+* http://stopwritingramblingcommitmessages.com
+* http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
-Bad commit message:
+To sum them up, the commit message has to be crystal clear and of course,
+related to the PR content.
+
+The first line of the commit message must be short, keep it under 50
+characters. It must say concisely but *precisely* what you did. The other
+lines, if needed, should contain a complete description of *why* you did this.
+
+Bad commit message subject:
 
 ```
-Update Admin.php
+Update README.md
 ```
 
-Good commit message:
+Good commit message subject :
 
 ```
-Improve search indexing speed for sub-categories
+Document how to install the project
 ```
 
-Good commit message with description
+Also, when you specify what you did avoid commit message subjects with "Fix bug
+in such and such feature". Saying you are fixing something implies the previous
+implementation was wrong and yours is right, which might not be even true.
+Instead, humbly say what you did technically and **then** explain how this is
+supposed to fix a bug. Your commit message will probably look like this:
+
+```
+call foo::bar() instead of bar::baz()
+
+This fixes a bug that arises when doing this or that, because baz() needs a
+flux capacitor object that might not be defined.
+Fixes #42
+```
+
+The description is optional but strongly recommended. It could be asked by the
+team if needed. PR will often lead to complicated, hard-to-read conversations
+with many links to other web pages.
+
+he commit description should be able to live without what is said in the PR,
+and should ideally sum it up in a crystal clear way, so that people do not have
+to open a web browser to understand what you did.
+Links to PRs/Issues and external references are of course welcome, but should
+not be considered enough.
+
+Good commit message with description :
 
 ```
 Change web UI background color to pink
@@ -100,5 +135,4 @@ This is a consensus made on #4242 in addition to #1337.
 
 We agreed that blank color is boring and so deja vu. Pink is the new way to do.
 ```
-
 (Obviously, this commit is fake. :wink:)

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Here is a short table resuming on which you have to start:
 Kind of modification | Backward Compatible (BC) | Type of release | Branch to target | Label |
 -------------------- | ------------------------ | --------------- | ---------------- | ----- |
 Bug fixes            | Yes                      | Patch           | `[latest].x`     | |
-Bug fixes            | No                       | Patch           | `master`         | |
+Bug fixes            | No (Only if no choice)   | Major           | `master`         | |
 Feature              | Yes                      | Minor           | `[latest].x`     | |
 Feature              | No (Only if no choice)   | Major           | `master`         | |
 Deprecation          | Yes (Have to)            | Minor           | `[latest].x`     | |

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -54,3 +54,8 @@ Notes:
     * Code deletion? Don't. Please deprecate it instead.
     * If your BC PR is accepted, you can do a new one on the `master` branch which remove the deprecated code.
     * SYMFONY DOC REF (same logic)?
+
+Be aware that pull requests with BC breaks could be not accepted
+or reported for next major release if BC is not possible.
+
+If you are not sure of what to do, don't hesitate to open an issue about your PR project.

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -105,9 +105,9 @@ Document how to install the project
 Also, when you specify what you did avoid commit message subjects with "Fix bug
 in such and such feature". Saying you are fixing something implies the previous
 implementation was wrong and yours is right, which might not be even true.
-Instead, humbly say what you did technically and **then** explain how this is
-supposed to fix a bug. Your commit message will probably look like this:
-
+Instead, state unquestionable technical facts about your changes, not opinions.
+Then, in the commit description, explain why you did that and how it fixes
+something.
 ```
 call foo::bar() instead of bar::baz()
 
@@ -120,7 +120,7 @@ The description is optional but strongly recommended. It could be asked by the
 team if needed. PR will often lead to complicated, hard-to-read conversations
 with many links to other web pages.
 
-he commit description should be able to live without what is said in the PR,
+The commit description should be able to live without what is said in the PR,
 and should ideally sum it up in a crystal clear way, so that people do not have
 to open a web browser to understand what you did.
 Links to PRs/Issues and external references are of course welcome, but should

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -29,6 +29,16 @@ php-cs-fixer fix --verbose
 
 ### Writing a Pull Requests
 
+#### The content
+
+A Pull Request should concern one and **only one** subject.
+
+If you want to fix a typo and improve the performance of a process, you have to do two **separated** PR.
+
+The goal is to have a clear commit history and make possible revert easier.
+
+If you found an issue/typo while writing your change that is not related to your work, please do another PR for that.
+
 #### The base branch
 
 Before writing a PR, you have to check on which branch your changes should be based.
@@ -59,3 +69,36 @@ Be aware that pull requests with BC breaks could be not accepted
 or reported for next major release if BC is not possible.
 
 If you are not sure of what to do, don't hesitate to open an issue about your PR project.
+
+#### The commit message
+
+The commit message has to be clear and related to the PR content.
+
+The first line of the commit message must be short.
+The other lines must contains a complete description of what you done and why.
+
+The description is optional but recommended. It could be asked by the team if needed.
+
+Bad commit message:
+
+```
+Update Admin.php
+```
+
+Good commit message:
+
+```
+Improve search indexing speed for sub-categories
+```
+
+Good commit message with description
+
+```
+Change web UI background color to pink
+
+This is a consensus made on #4242 in addition to #1337.
+
+We agreed that blank color is boring and so deja vu. Pink is the new way to do.
+```
+
+(Obviously, this commit is fake. :wink:)

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Sonata project contribution
+
+Thanks for you interest onto Sonata projects!
+
+## Summary
+
+* [Issues]()
+* [Pull Request]()
+* [Label rules]()


### PR DESCRIPTION
Here is the first PR of `dev-kit` about contributing documentation. :tada:

At the end, the root `CONTRIBUTING.md` file will be dispatched on all sonata-project repositories.

This documentation will be the only reference.

The goal is to **clarify all the rules** and be **consistent**.

Please dear @sonata-project/contributors, don't hesitate to discuss on this PR to add contributions like:

* Propose summary item
* Suggest some details
* Correct typos
* Whatever!

Please comment on the **PR diff** so old comments will be automatically deleted when fixed.

In any case, this issue will be the start: https://github.com/sonata-project/SonataAdminBundle/issues/3053

Thanks you all. :heart: 

To do list:

- [ ] Defined a "Deprecation best practices" with examples
- [ ] BC definition
- [ ] Another? Feel free to comment!
- [ ] PR submission: issue link
- [ ] PR for one thing only. Introduce and explain "If this line does not concern your change goal, does not touch it." rules (squash incident, more complicated revert/history...)
- [ ] Team: Issue management (composer show, title edit etc...)
- [ ] Team: Pull Request management (Merge by squash, look for BC, waiting CI green etc...)
- [ ] BC break or deprecation -> upgrade note.