### PR TITLE
Force unaligning equal signs and arrows

### DIFF
--- a/project/.styleci.yml
+++ b/project/.styleci.yml
@@ -7,7 +7,6 @@
 preset: symfony
 
 enabled:
-  - align_double_arrow
   - newline_after_open_tag
   - ordered_use
   - long_array_syntax
@@ -16,10 +15,6 @@ enabled:
 #  - strict_param
 #  - php_unit_construct
 #  - php_unit_strict
-
-disabled:
-  - unalign_double_arrow
-  - unalign_equals
 
 finder:
   exclude:

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -194,7 +194,7 @@ class DispatchCommand extends Command
                 $state = 'Updated';
                 if ($this->apply) {
                     $this->githubClient->repo()->labels()->update(static::GITHUB_GROUP, $repositoryName, $name, array(
-                        'name'  => $name,
+                        'name' => $name,
                         'color' => $configuredColor,
                     ));
                 }
@@ -215,7 +215,7 @@ class DispatchCommand extends Command
 
             if ($this->apply) {
                 $this->githubClient->repo()->labels()->create(static::GITHUB_GROUP, $repositoryName, array(
-                    'name'  => $name,
+                    'name' => $name,
                     'color' => $color,
                 ));
             }


### PR DESCRIPTION
Alignment can seem like a good idea at first, but it makes diff harder
to read, and bigger, thus increasing the risk of conflicts. It also adds
a load on the developer because it requires maintenance when they add or
remove the longest key of the array / variable of the assignment list.