### PR TITLE
adds indent size settings for js, json, scss & css

### DIFF
--- a/tools/editorconfig/.editorconfig
+++ b/tools/editorconfig/.editorconfig
@@ -10,6 +10,9 @@ trim_trailing_whitespace = true
 [*.{yml,twig,php}]
 indent_size = 4
 
+[*.{js,json,scss,css}]
+indent_size = 2
+
 [.travis-ci.yml]
 indent_size = 2
 


### PR DESCRIPTION
A popular convention is to use 2 spaces for indenting js & css files.
One could also choose 4 spaces, to favour consistency with other file types among the project.
I do not have any kind of preference on this really, so just react with:
* :+1: if you're ok with 2 spaces
* :-1: if you prefer 4