### PR TITLE
adds indent size setting for package.json

### DIFF
--- a/tools/editorconfig/.editorconfig
+++ b/tools/editorconfig/.editorconfig
@@ -10,7 +10,7 @@ trim_trailing_whitespace = true
 [*.{yml,twig,php}]
 indent_size = 4
 
-[.travis-ci.yml]
+[{package.json,.travis-ci.yml}]
 indent_size = 2
 
 [composer.json]


### PR DESCRIPTION
Use npm's default indent size, so that people don't mess with it accidentally
when editing the file by hand.