### PR TITLE
Label update automation

### DIFF
--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -9,6 +9,10 @@ labels:
     color: 'fc2929'
   - name: vendor
     color: 'ededed'
+  - name: pending author
+    color: 'dddddd'
+  - name: RTM
+    color: 'ffffff'
 
 projects:
   cache: ~

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -10,7 +10,9 @@ labels:
   - name: vendor
     color: 'ededed'
   - name: pending author
-    color: 'dddddd'
+    color: 'ededed'
+  - name: in progress
+    color: 'ededed'
   - name: RTM
     color: 'ffffff'
   - name: docs

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -19,35 +19,35 @@ labels:
     color: 'd4c5f9'
 
 projects:
-  admin-bundle: ~
-  admin-search-bundle: ~
-  block-bundle: ~
+#  admin-bundle: ~
+#  admin-search-bundle: ~
+#  block-bundle: ~
   cache: ~
-  cache-bundle: ~
-  classification-bundle: ~
-  comment-bundle: ~
-  composer-archive-creator: ~
-  core-bundle: ~
-  dashboard-bundle: ~
-  datagrid-bundle: ~
-  doctrine-extensions: ~
-  doctrine-mongodb-admin-bundle: ~
-  doctrine-orm-admin-bundle: ~
-  doctrine-phpcr-admin-bundle: ~
-  easy-extends-bundle: ~
-  ecommerce: ~
+#  cache-bundle: ~
+#  classification-bundle: ~
+#  comment-bundle: ~
+#  composer-archive-creator: ~
+#  core-bundle: ~
+#  dashboard-bundle: ~
+#  datagrid-bundle: ~
+#  doctrine-extensions: ~
+#  doctrine-mongodb-admin-bundle: ~
+#  doctrine-orm-admin-bundle: ~
+#  doctrine-phpcr-admin-bundle: ~
+#  easy-extends-bundle: ~
+#  ecommerce: ~
   exporter: ~
-  formatter-bundle: ~
-  google-authenticator: ~
-  intl-bundle: ~
-  media-bundle: ~
-  news-bundle: ~
-  notification-bundle: ~
-  page-bundle: ~
-  propel-admin-bundle: ~
-  sandbox: ~
-  seo-bundle: ~
-  sonata-composer: ~
-  timeline-bundle: ~
-  translation-bundle: ~
-  user-bundle: ~
+#  formatter-bundle: ~
+#  google-authenticator: ~
+#  intl-bundle: ~
+#  media-bundle: ~
+#  news-bundle: ~
+#  notification-bundle: ~
+#  page-bundle: ~
+#  propel-admin-bundle: ~
+#  sandbox: ~
+#  seo-bundle: ~
+#  sonata-composer: ~
+#  timeline-bundle: ~
+#  translation-bundle: ~
+#  user-bundle: ~

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -7,6 +7,8 @@ labels:
     color: 'e11d21'
   - name: bug
     color: 'fc2929'
+  - name: critical
+    color: 'fc2929'
   - name: vendor
     color: 'ededed'
   - name: pending author

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -13,6 +13,10 @@ labels:
     color: 'dddddd'
   - name: RTM
     color: 'ffffff'
+  - name: docs
+    color: 'fbca04'
+  - name: review required
+    color: 'd4c5f9'
 
 projects:
   admin-bundle: ~

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -1,0 +1,16 @@
+labels:
+  - name: patch
+    color: '207de5'
+  - name: minor
+    color: '009800'
+  - name: major
+    color: 'e11d21'
+  - name: bug
+    color: 'fc2929'
+  - name: vendor
+    color: 'ededed'
+
+projects:
+  cache: ~
+  exporter: ~
+  admin-bundle: ~

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -21,6 +21,8 @@ labels:
     color: 'fbca04'
   - name: review required
     color: 'd4c5f9'
+  - name: help wanted
+    color: '0e8a16'
 
 projects:
   admin-bundle: ~

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -23,35 +23,35 @@ labels:
     color: 'd4c5f9'
 
 projects:
-#  admin-bundle: ~
-#  admin-search-bundle: ~
-#  block-bundle: ~
+  admin-bundle: ~
+  admin-search-bundle: ~
+  block-bundle: ~
   cache: ~
-#  cache-bundle: ~
-#  classification-bundle: ~
-#  comment-bundle: ~
-#  composer-archive-creator: ~
-#  core-bundle: ~
-#  dashboard-bundle: ~
-#  datagrid-bundle: ~
-#  doctrine-extensions: ~
-#  doctrine-mongodb-admin-bundle: ~
-#  doctrine-orm-admin-bundle: ~
-#  doctrine-phpcr-admin-bundle: ~
-#  easy-extends-bundle: ~
-#  ecommerce: ~
+  cache-bundle: ~
+  classification-bundle: ~
+  comment-bundle: ~
+  composer-archive-creator: ~
+  core-bundle: ~
+  dashboard-bundle: ~
+  datagrid-bundle: ~
+  doctrine-extensions: ~
+  doctrine-mongodb-admin-bundle: ~
+  doctrine-orm-admin-bundle: ~
+  doctrine-phpcr-admin-bundle: ~
+  easy-extends-bundle: ~
+  ecommerce: ~
   exporter: ~
-#  formatter-bundle: ~
-#  google-authenticator: ~
-#  intl-bundle: ~
-#  media-bundle: ~
-#  news-bundle: ~
-#  notification-bundle: ~
-#  page-bundle: ~
-#  propel-admin-bundle: ~
-#  sandbox: ~
-#  seo-bundle: ~
-#  sonata-composer: ~
-#  timeline-bundle: ~
-#  translation-bundle: ~
-#  user-bundle: ~
+  formatter-bundle: ~
+  google-authenticator: ~
+  intl-bundle: ~
+  media-bundle: ~
+  news-bundle: ~
+  notification-bundle: ~
+  page-bundle: ~
+  propel-admin-bundle: ~
+  sandbox: ~
+  seo-bundle: ~
+  sonata-composer: ~
+  timeline-bundle: ~
+  translation-bundle: ~
+  user-bundle: ~

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -15,6 +15,35 @@ labels:
     color: 'ffffff'
 
 projects:
-  cache: ~
-  exporter: ~
   admin-bundle: ~
+  admin-search-bundle: ~
+  block-bundle: ~
+  cache: ~
+  cache-bundle: ~
+  classification-bundle: ~
+  comment-bundle: ~
+  composer-archive-creator: ~
+  core-bundle: ~
+  dashboard-bundle: ~
+  datagrid-bundle: ~
+  doctrine-extensions: ~
+  doctrine-mongodb-admin-bundle: ~
+  doctrine-orm-admin-bundle: ~
+  doctrine-phpcr-admin-bundle: ~
+  easy-extends-bundle: ~
+  ecommerce: ~
+  exporter: ~
+  formatter-bundle: ~
+  google-authenticator: ~
+  intl-bundle: ~
+  media-bundle: ~
+  news-bundle: ~
+  notification-bundle: ~
+  page-bundle: ~
+  propel-admin-bundle: ~
+  sandbox: ~
+  seo-bundle: ~
+  sonata-composer: ~
+  timeline-bundle: ~
+  translation-bundle: ~
+  user-bundle: ~

--- a/.sonata-project.yml
+++ b/.sonata-project.yml
@@ -23,35 +23,35 @@ labels:
     color: 'd4c5f9'
 
 projects:
-  admin-bundle: ~
-  admin-search-bundle: ~
-  block-bundle: ~
+#  admin-bundle: ~
+#  admin-search-bundle: ~
+#  block-bundle: ~
   cache: ~
-  cache-bundle: ~
-  classification-bundle: ~
-  comment-bundle: ~
-  composer-archive-creator: ~
-  core-bundle: ~
-  dashboard-bundle: ~
-  datagrid-bundle: ~
-  doctrine-extensions: ~
-  doctrine-mongodb-admin-bundle: ~
-  doctrine-orm-admin-bundle: ~
-  doctrine-phpcr-admin-bundle: ~
-  easy-extends-bundle: ~
-  ecommerce: ~
+#  cache-bundle: ~
+#  classification-bundle: ~
+#  comment-bundle: ~
+#  composer-archive-creator: ~
+#  core-bundle: ~
+#  dashboard-bundle: ~
+#  datagrid-bundle: ~
+#  doctrine-extensions: ~
+#  doctrine-mongodb-admin-bundle: ~
+#  doctrine-orm-admin-bundle: ~
+#  doctrine-phpcr-admin-bundle: ~
+#  easy-extends-bundle: ~
+#  ecommerce: ~
   exporter: ~
-  formatter-bundle: ~
-  google-authenticator: ~
-  intl-bundle: ~
-  media-bundle: ~
-  news-bundle: ~
-  notification-bundle: ~
-  page-bundle: ~
-  propel-admin-bundle: ~
-  sandbox: ~
-  seo-bundle: ~
-  sonata-composer: ~
-  timeline-bundle: ~
-  translation-bundle: ~
-  user-bundle: ~
+#  formatter-bundle: ~
+#  google-authenticator: ~
+#  intl-bundle: ~
+#  media-bundle: ~
+#  news-bundle: ~
+#  notification-bundle: ~
+#  page-bundle: ~
+#  propel-admin-bundle: ~
+#  sandbox: ~
+#  seo-bundle: ~
+#  sonata-composer: ~
+#  timeline-bundle: ~
+#  translation-bundle: ~
+#  user-bundle: ~

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
+  - composer config -q -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
 
 install:
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
-  - if [ "$TRAVIS_BRANCH" = "master" ]; then ./dev-kit dispatch --apply; else ./dev-kit dispatch; fi;
+  - if [[ "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]; then ./dev-kit dispatch --apply; else ./dev-kit dispatch; fi;

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,8 @@
     ],
     "require-dev": {
         "php": "^5.6 || 7.0",
+        "knplabs/github-api": "^1.6",
+        "knplabs/packagist-api": "^1.3",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/console": "^3.0"
     },
@@ -18,5 +20,9 @@
     "config": {
         "sort-packages": true,
         "optimize-autoloader": true
+    },
+    "require": {
+        "symfony/config": "^3.0",
+        "symfony/var-dumper": "^3.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
         "knplabs/github-api": "^1.6",
         "knplabs/packagist-api": "^1.3",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/console": "^3.0"
+        "symfony/config": "^3.0",
+        "symfony/console": "^3.0",
+        "symfony/var-dumper": "^3.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\DevKit\\": "src" }
@@ -20,9 +22,5 @@
     "config": {
         "sort-packages": true,
         "optimize-autoloader": true
-    },
-    "require": {
-        "symfony/config": "^3.0",
-        "symfony/var-dumper": "^3.0"
     }
 }

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DevKit\Config;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('sonata');
+
+        $rootNode
+            ->children()
+                ->arrayNode('labels')
+                    ->isRequired()
+                    ->requiresAtLeastOneElement()
+                    ->useAttributeAsKey('name')
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('color')->isRequired()->cannotBeEmpty()->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('projects')
+                    ->isRequired()
+                    ->requiresAtLeastOneElement()
+                    ->normalizeKeys(false)
+                    ->prototype('scalar')->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -77,11 +77,7 @@ class DispatchCommand extends Command
 
         $this->packagistClient = new \Packagist\Api\Client();
 
-        $this->githubClient = new \Github\Client(
-            new \Github\HttpClient\CachedHttpClient(array(
-                'cache_dir' => sys_get_temp_dir().'/github-api-cache',
-            ))
-        );
+        $this->githubClient = new \Github\Client();
         if (getenv('GITHUB_OAUTH_TOKEN')) {
             $this->githubClient->authenticate(getenv('GITHUB_OAUTH_TOKEN'), null, \Github\Client::AUTH_HTTP_TOKEN);
         }

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -27,9 +27,9 @@ use Symfony\Component\Yaml\Yaml;
 class DispatchCommand extends Command
 {
     /**
-     * @var InputInterface
+     * @var bool
      */
-    private $input;
+    private $apply;
 
     /**
      * @var SymfonyStyle
@@ -69,7 +69,7 @@ class DispatchCommand extends Command
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $this->io = new SymfonyStyle($input, $output);
-        $this->input = $input;
+        $this->apply = $input->getOption('apply');
 
         $configs = Yaml::parse(file_get_contents(__DIR__.'/../../../.sonata-project.yml'));
         $processor = new Processor();
@@ -88,6 +88,7 @@ class DispatchCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        dump($this->apply);
         foreach ($this->configs['projects'] as $name => $projectConfig) {
             $package = $this->packagistClient->get('sonata-project/'.$name);
             $this->io->title($package->getName());
@@ -139,12 +140,12 @@ class DispatchCommand extends Command
             $state = null;
             if (!$shouldExist) {
                 $state = 'Deleted';
-                if ($this->input->getOption('apply')) {
+                if ($this->apply) {
                     $this->githubClient->repo()->labels()->remove('sonata-project', $repositoryName, $name);
                 }
             } elseif ($shouldBeUpdated) {
                 $state = 'Updated';
-                if ($this->input->getOption('apply')) {
+                if ($this->apply) {
                     $this->githubClient->repo()->labels()->update('sonata-project', $repositoryName, $name, array(
                         'name'  => $name,
                         'color' => $configuredColor,
@@ -163,7 +164,7 @@ class DispatchCommand extends Command
         foreach ($missingLabels as $name => $label) {
             $color = $label['color'];
 
-            if ($this->input->getOption('apply')) {
+            if ($this->apply) {
                 $this->githubClient->repo()->labels()->create('sonata-project', $repositoryName, array(
                     'name'  => $name,
                     'color' => $color,

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -128,16 +128,16 @@ class DispatchCommand extends Command
             $name = $label['name'];
             $color = $label['color'];
 
-            $shouldExists = array_key_exists($name, $configuredLabels);
-            $configuredColor = $shouldExists ? $configuredLabels[$name]['color'] : null;
-            $shouldBeUpdated = $shouldExists && $color !== $configuredColor;
+            $shouldExist = array_key_exists($name, $configuredLabels);
+            $configuredColor = $shouldExist ? $configuredLabels[$name]['color'] : null;
+            $shouldBeUpdated = $shouldExist && $color !== $configuredColor;
 
-            if ($shouldExists) {
+            if ($shouldExist) {
                 unset($missingLabels[$name]);
             }
 
             $state = null;
-            if (!$shouldExists) {
+            if (!$shouldExist) {
                 $state = 'Deleted';
                 if ($this->input->getOption('apply')) {
                     $this->githubClient->repo()->labels()->remove('sonata-project', $repositoryName, $name);

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DevKit\Console\Command;
 
+use Github\Exception\ExceptionInterface;
 use Packagist\Api\Result\Package;
 use Sonata\DevKit\Config\Configuration;
 use Symfony\Component\Config\Definition\Processor;
@@ -93,9 +94,13 @@ class DispatchCommand extends Command
         }
 
         foreach ($this->configs['projects'] as $name => $projectConfig) {
-            $package = $this->packagistClient->get('sonata-project/'.$name);
-            $this->io->title($package->getName());
-            $this->updateLabels($this->getRepositoryName($package));
+            try {
+                $package = $this->packagistClient->get('sonata-project/'.$name);
+                $this->io->title($package->getName());
+                $this->updateLabels($this->getRepositoryName($package));
+            } catch (ExceptionInterface $e) {
+                $this->io->error('Failed with message: '.$e->getMessage());
+            }
         }
 
         return 0;

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -152,12 +152,14 @@ class DispatchCommand extends Command
                 }
             }
 
-            array_push($rows, array(
-                $name,
-                '#'.$color,
-                $configuredColor ? '#'.$configuredColor : 'N/A',
-                $state ?: '-',
-            ));
+            if ($state) {
+                array_push($rows, array(
+                    $name,
+                    '#'.$color,
+                    $configuredColor ? '#'.$configuredColor : 'N/A',
+                    $state,
+                ));
+            }
         }
 
         foreach ($missingLabels as $name => $label) {

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -11,11 +11,15 @@
 
 namespace Sonata\DevKit\Console\Command;
 
+use Packagist\Api\Result\Package;
+use Sonata\DevKit\Config\Configuration;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -26,6 +30,21 @@ class DispatchCommand extends Command
      * @var SymfonyStyle
      */
     private $io;
+
+    /**
+     * @var array
+     */
+    private $configs;
+
+    /**
+     * @var \Packagist\Api\Client
+     */
+    private $packagistClient;
+
+    /**
+     * @var \Github\Client
+     */
+    private $githubClient = false;
 
     /**
      * {@inheritdoc}
@@ -45,6 +64,21 @@ class DispatchCommand extends Command
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $this->io = new SymfonyStyle($input, $output);
+
+        $configs = Yaml::parse(file_get_contents(__DIR__.'/../../../.sonata-project.yml'));
+        $processor = new Processor();
+        $this->configs = $processor->processConfiguration(new Configuration(), array('sonata' => $configs));
+
+        $this->packagistClient = new \Packagist\Api\Client();
+
+        $this->githubClient = new \Github\Client(
+            new \Github\HttpClient\CachedHttpClient(array(
+                'cache_dir' => sys_get_temp_dir().'/github-api-cache',
+            ))
+        );
+        if (getenv('GITHUB_OAUTH_TOKEN')) {
+            $this->githubClient->authenticate(getenv('GITHUB_OAUTH_TOKEN'));
+        }
     }
 
     /**
@@ -52,6 +86,72 @@ class DispatchCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        foreach ($this->configs['projects'] as $name => $projectConfig) {
+            $package = $this->packagistClient->get('sonata-project/'.$name);
+            $this->io->title($package->getName());
+            $this->updateLabels($this->getRepositoryName($package));
+        }
+
         return 0;
+    }
+
+    /**
+     * Returns repository name without vendor prefix.
+     *
+     * @param Package $package
+     *
+     * @return string
+     */
+    private function getRepositoryName(Package $package)
+    {
+        $repositoryArray = explode('/', $package->getRepository());
+
+        return str_replace('.git', '', end($repositoryArray));
+    }
+
+    /**
+     * @param string $repositoryName
+     */
+    private function updateLabels($repositoryName)
+    {
+        $this->io->section('Labels');
+
+        $configuredLabels = $this->configs['labels'];
+        $missingLabels = $configuredLabels;
+
+        $headers = array('Name', 'Actual color', 'Needed Color', 'State');
+        $rows = array();
+
+        foreach ($this->githubClient->repository()->labels()->all('sonata-project', $repositoryName) as $label) {
+            $name = $label['name'];
+            $color = $label['color'];
+
+            $shouldExists = array_key_exists($name, $configuredLabels);
+            $configuredColor = $shouldExists ? $configuredLabels[$name]['color'] : null;
+            $shouldBeUpdated = $shouldExists && $color !== $configuredColor;
+
+            if ($shouldExists) {
+                unset($missingLabels[$name]);
+            }
+
+            array_push($rows, array(
+                $name,
+                '#'.$color,
+                $configuredColor ? '#'.$configuredColor : 'N/A',
+                $shouldExists ? $shouldBeUpdated ? 'Updated' : '-' : 'Deleted',
+            ));
+        }
+
+        foreach ($missingLabels as $name => $label) {
+            $color = $label['color'];
+
+            array_push($rows, array($name, 'N/A', '#'.$color, 'Created'));
+        }
+
+        usort($rows, function ($row1, $row2) {
+            return strcasecmp($row1[0], $row2[0]);
+        });
+
+        $this->io->table($headers, $rows);
     }
 }

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -77,7 +77,7 @@ class DispatchCommand extends Command
             ))
         );
         if (getenv('GITHUB_OAUTH_TOKEN')) {
-            $this->githubClient->authenticate(getenv('GITHUB_OAUTH_TOKEN'));
+            $this->githubClient->authenticate(getenv('GITHUB_OAUTH_TOKEN'), null, \Github\Client::AUTH_HTTP_TOKEN);
         }
     }
 

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -88,6 +88,10 @@ class DispatchCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!$this->apply) {
+            $this->io->warning('This is a dry run execution. No change will be applied here.');
+        }
+
         foreach ($this->configs['projects'] as $name => $projectConfig) {
             $package = $this->packagistClient->get('sonata-project/'.$name);
             $this->io->title($package->getName());
@@ -178,6 +182,14 @@ class DispatchCommand extends Command
             return strcasecmp($row1[0], $row2[0]);
         });
 
-        $this->io->table($headers, $rows);
+        if (empty($rows)) {
+            $this->io->comment('Nothing to be changed.');
+        } else {
+            $this->io->table($headers, $rows);
+
+            if ($this->apply) {
+                $this->io->success('Labels successfully updated.');
+            }
+        }
     }
 }

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -88,7 +88,6 @@ class DispatchCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        dump($this->apply);
         foreach ($this->configs['projects'] as $name => $projectConfig) {
             $package = $this->packagistClient->get('sonata-project/'.$name);
             $this->io->title($package->getName());


### PR DESCRIPTION
The goal of this PR is to update all labels of all sonata project.

For the moment, it just output what it should do.

@sonata-project/contributors Please take profits to discuss which label should be added on the list and why (just for label, not color).

This should be done now because all other not wanted labels **will be destroyed**.

You can see the output on Travis jobs.

- [x] Make update real (test only on `cache` and `exporter` for now)
- [x] Only show updated/deleted label
- [x] Success message at end