### PR TITLE
Use a restore / backup strategy for xdebug

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -49,7 +49,7 @@ matrix:
 {% endif %}
 
 before_install:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then mv "$HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini" /tmp; fi;
   - composer config --quiet --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
   - composer global require phpunit/phpunit:@stable --no-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
@@ -60,6 +60,6 @@ install:
   - pip install -r {{ docs_path }}/requirements.txt --user `whoami`
 
 before_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "zend_extension=xdebug.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then mv /tmp/xdebug.ini "$HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d"; fi;
 
 script: make $TARGET


### PR DESCRIPTION
For some reason, xdebug.so cannot be found when using config-rm.
Fixes #34