### PR TITLE
Replace dev-master by dev-${TRAVIS_COMMIT} on Travis

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -52,6 +52,7 @@ before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then mv "$HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini" /tmp; fi;
   - composer config --quiet --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
   - composer global require phpunit/phpunit:@stable --no-update
+  - sed --in-place "s/\"dev-master\":/\"dev-${TRAVIS_COMMIT}\":/" composer.json
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
 install:


### PR DESCRIPTION
Related issue: https://github.com/sonata-project/SonataBlockBundle/issues/266

If the root package require a package that require root itself,
the circular dependencies resolving will fail targeting the wrong dev branch.

Replacing dev-master by the complete commit reference solve this issue.

Note that issue only appear on Travis job, doing a cloning like this:

git clone --depth=50 --branch=3.0.0 https://github.com/sonata-project/SonataBlockBundle.git sonata-project/SonataBlockBundle

This issue does not appear on a "classic" repository clone.