### PR TITLE
Set --prefer-stable option as default

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -57,7 +57,7 @@ before_install:
 
 install:
   - travis_wait composer global update --prefer-dist --no-interaction
-  - travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+  - travis_wait composer update --prefer-dist --no-interaction --prefer-stable $COMPOSER_FLAGS
   - pip install -r {{ docs_path }}/requirements.txt --user `whoami`
 
 before_script:


### PR DESCRIPTION
For some reasons like fixing cirular dependencies, we have to add @dev dependencies

See: https://github.com/sonata-project/SonataAdminBundle/pull/3777

But if we do that, only dev dependencies will be installed for test, this is not what we want.

This is why I added --prefer-stable option on composer update process.

The next step would be to remove this option on allow_failures section if the following issue is resolved.

https://github.com/travis-ci/travis-ci/issues/6021