### PR TITLE
Fixed link to documentation file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 Thanks for you interest onto Sonata projects!
 
 Want to contribute? Please read the following documentation first:
-[dev-kit/doc/CONTRIBUTING.md](https://github.com/sonata-project/dev-kit/blob/master/doc/CONTRIBUTING.md).
+[dev-kit/project/CONTRIBUTING.md](https://github.com/sonata-project/dev-kit/project/CONTRIBUTING.md).
 
 This is the only documentation you have to refer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 Thanks for you interest onto Sonata projects!
 
 Want to contribute? Please read the following documentation first:
-[dev-kit/project/CONTRIBUTING.md](https://github.com/sonata-project/dev-kit/project/CONTRIBUTING.md).
+[dev-kit/project/CONTRIBUTING.md](https://github.com/sonata-project/dev-kit/blob/master/project/CONTRIBUTING.md).
 
 This is the only documentation you have to refer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 Thanks for you interest onto Sonata projects!
 
 Want to contribute? Please read the following documentation first:
-[dev-kit/project/CONTRIBUTING.md].
+[project/CONTRIBUTING.md](project/CONTRIBUTING.md).
 
 This is the only documentation you have to refer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 Thanks for you interest onto Sonata projects!
 
 Want to contribute? Please read the following documentation first:
-[dev-kit/project/CONTRIBUTING.md](https://github.com/sonata-project/dev-kit/blob/master/project/CONTRIBUTING.md).
+[dev-kit/project/CONTRIBUTING.md].
 
 This is the only documentation you have to refer.


### PR DESCRIPTION
The name of the directory containing the real CONTRIBUTING.md file seems to have changed. This PR serves to update the link appropriately.