### PR TITLE
Increase PHP memory limit on Travis

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -50,6 +50,7 @@ matrix:
 
 before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then mv "$HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini" /tmp; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit=3072M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
 {# To be removed when following PR will be merged: https://github.com/travis-ci/travis-build/pull/718 #}
   - if [ "$TARGET" = 'test' ]; then composer self-update --stable; fi;
   - if [ "$TARGET" = 'test' ]; then composer config --quiet --global github-oauth.github.com $GITHUB_OAUTH_TOKEN; fi;


### PR DESCRIPTION
Some composer jobs fail on Travis.

Example: https://travis-ci.org/sonata-project/SonataUserBundle/jobs/130076312#L210