### PR TITLE
Add Sonata core, admin and block bundles targets on Travis

### DIFF
--- a/config/dev-kit.yml
+++ b/config/dev-kit.yml
@@ -37,3 +37,6 @@ labels:
 packages:
   symfony: symfony/symfony
   fos_user: friendsofsymfony/user-bundle
+  sonata_core: sonata-project/core-bundle
+  sonata_admin: sonata-project/admin-bundle
+  sonata_block: sonata-project/block-bundle

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -4,10 +4,14 @@ admin-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        sonata_core: ['3']
+        sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        sonata_core: ['3']
+        sonata_block: ['3']
 
 admin-search-bundle: ~
 
@@ -17,10 +21,14 @@ block-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        sonata_core: ['3']
+        sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        sonata_core: ['3']
+        sonata_admin: ['3']
 
 cache: ~
 
@@ -55,10 +63,14 @@ doctrine-orm-admin-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        sonata_core: ['3']
+        sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        sonata_core: ['3']
+        sonata_admin: ['3']
 
 doctrine-phpcr-admin-bundle: ~
 
@@ -100,10 +112,14 @@ seo-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        sonata_block: ['3']
+        sonata_admin: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        sonata_block: ['3']
+        sonata_admin: ['3']
 
 sonata-composer: ~
 
@@ -118,3 +134,5 @@ user-bundle:
       versions:
         symfony: ['2.3', '2.6', '2.7', '2.8']
         fos_user: ['1.3']
+        sonata_core: ['3']
+        sonata_admin: ['3']


### PR DESCRIPTION
The goal is too ensure compatibility between internal sonata packages.

This could be improved later by combining packages targets to reduce Travis jobs, but we have to find a solution to check packages inter-compatibility before.