### PR TITLE
Manage RTM and 'review required' labels.

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -43,6 +43,10 @@ $app->post('/github', function (Request $request) use ($app, $githubHookProcesso
             $githubHookProcessor->processPendingAuthor($eventName, $payload);
 
             return new Response();
+        case 'pull_request':
+            $githubHookProcessor->processReviewLabels($eventName, $payload);
+
+            return new Response();
         case 'pull_request_review_comment':
             $githubHookProcessor->processPendingAuthor($eventName, $payload);
 


### PR DESCRIPTION
- If a PR is opened or updated, 'review required' is set.
- If a PR is updated and 'RTM' is set, it is removed.

This is a pre-sequel of PR merging automation.