### PR TITLE
Drop Symfony 2.6 testing support

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -3,13 +3,13 @@ admin-bundle:
     master:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -20,13 +20,13 @@ block-bundle:
     master:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
         sonata_core: ['3']
         # This has to be resolved: https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/130298942#L230
         #sonata_admin: ['3']
@@ -44,11 +44,11 @@ core-bundle:
     master:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
 
 dashboard-bundle: ~
 
@@ -63,13 +63,13 @@ doctrine-orm-admin-bundle:
     master:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
         sonata_core: ['3']
         sonata_admin: ['3']
 
@@ -91,7 +91,7 @@ exporter:
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
       docs_path: docs
 
 formatter-bundle: ~
@@ -117,13 +117,13 @@ seo-bundle:
     master:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8', '3.0']
+        symfony: ['2.3', '2.7', '2.8', '3.0']
         sonata_block: ['3']
         sonata_admin: ['3']
 
@@ -138,7 +138,7 @@ user-bundle:
     master:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.6', '2.7', '2.8']
+        symfony: ['2.3', '2.7', '2.8']
         fos_user: ['1.3']
         sonata_core: ['3']
         sonata_admin: ['3']


### PR DESCRIPTION
The security support of Symfony 2.6 has ended in January 2016. Use 2.7 or 2.8 LTS version instead.
http://symfony.com/roadmap?version=2.6#checker