### PR TITLE
Add workaround for composer --prefer-lowest issue

### DIFF
--- a/project/.travis/install_test.sh
+++ b/project/.travis/install_test.sh
@@ -12,4 +12,8 @@ fi
 wget "https://phar.phpunit.de/${PHPUNIT_PHAR}" --output-document="${HOME}/bin/phpunit"
 chmod u+x "${HOME}/bin/phpunit"
 
+# To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
+if [ ${COMPOSER_FLAGS} = '--prefer-lowest' ]; then
+    composer update --prefer-dist --no-interaction --prefer-stable --quiet
+fi
 composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}


### PR DESCRIPTION
We needs to do a 'classic' composer update before doing the --prefer-lowest one.

This can be removed when the following issue will be resolved:

https://github.com/composer/composer/issues/5355