### PR TITLE
Pull Requests auto merge when submitted by bots

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^5.5 || 7.0",
         "cpliakas/git-wrapper": "^1.7",
         "doctrine/inflector": "^1.1",
-        "knplabs/github-api": "^1.6",
+        "knplabs/github-api": "dev-master",
         "knplabs/packagist-api": "^1.3",
         "sebastian/diff": "^1.4",
         "silex/silex": "^2.0",
@@ -25,9 +25,5 @@
     },
     "autoload": {
         "psr-4": { "Sonata\\DevKit\\": "src" }
-    },
-    "config": {
-        "sort-packages": true,
-        "optimize-autoloader": true
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -15,6 +15,7 @@ use Sonata\DevKit\Console\Command\AutoMergeCommand;
 use Sonata\DevKit\Console\Command\DependsCommand;
 use Sonata\DevKit\Console\Command\DispatchCommand;
 use Sonata\DevKit\Console\Command\MergeConflictsCommand;
+use Sonata\DevKit\Console\Command\PullRequestAutoMergeCommand;
 use Symfony\Component\Console\Application as BaseApplication;
 
 /**
@@ -33,5 +34,6 @@ class Application extends BaseApplication
         $this->add(new DependsCommand());
         $this->add(new MergeConflictsCommand());
         $this->add(new AutoMergeCommand());
+        $this->add(new PullRequestAutoMergeCommand());
     }
 }

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DevKit\Console\Command;
 
+use Github\HttpClient\HttpClient;
 use Packagist\Api\Result\Package;
 use Sonata\DevKit\Config\DevKitConfiguration;
 use Sonata\DevKit\Config\ProjectsConfiguration;
@@ -84,7 +85,10 @@ abstract class AbstractCommand extends Command
 
         $this->packagistClient = new \Packagist\Api\Client();
 
-        $this->githubClient = new GithubClient();
+        $this->githubClient = new GithubClient(new HttpClient(array(
+            // This version is needed for squash. https://developer.github.com/v3/pulls/#input-2
+            'api_version' => 'polaris-preview',
+        )));
         $this->githubPaginator = new \Github\ResultPager($this->githubClient);
         if ($this->githubAuthKey) {
             $this->githubClient->authenticate($this->githubAuthKey, null, \Github\Client::AUTH_HTTP_TOKEN);

--- a/src/Console/Command/PullRequestAutoMergeCommand.php
+++ b/src/Console/Command/PullRequestAutoMergeCommand.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DevKit\Console\Command;
+
+use Github\Exception\ExceptionInterface;
+use Packagist\Api\Result\Package;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class PullRequestAutoMergeCommand extends AbstractNeedApplyCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('pull-request-auto-merge')
+            ->setDescription('Merge RTM pull requests. Only active for StyleCI/SonataCI PR.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        foreach ($this->configs['projects'] as $name => $projectConfig) {
+            try {
+                $package = $this->packagistClient->get(static::PACKAGIST_GROUP.'/'.$name);
+                $this->io->title($package->getName());
+                $this->mergePullRequest($package, $projectConfig);
+            } catch (ExceptionInterface $e) {
+                $this->io->error('Failed with message: '.$e->getMessage());
+            }
+        }
+
+        return 0;
+    }
+
+    private function mergePullRequest(Package $package, array $projectConfig)
+    {
+        if (!array_key_exists('branches', $projectConfig)) {
+            return;
+        }
+
+        $repositoryName = $this->getRepositoryName($package);
+        $branches = array_keys($projectConfig['branches']);
+
+        $pulls = $this->githubPaginator->fetchAll($this->githubClient->pullRequests(), 'all', array(
+            static::GITHUB_GROUP,
+            $repositoryName,
+        ));
+        foreach ($pulls as $pull) {
+            // Do not managed not configured branches.
+            if (!in_array($pull['base']['ref'], $branches, true)) {
+                continue;
+            }
+
+            // Proceed only bot PR for now.
+            if ('SonataCI' !== $pull['user']['login']) {
+                continue;
+            }
+
+            $this->io->section(sprintf(
+                '#%d > %s - %s',
+                $pull['number'],
+                $pull['base']['ref'],
+                $pull['title']
+            ));
+
+            $state = $this->githubClient->repos()->statuses()->combined(
+                static::GITHUB_GROUP,
+                $repositoryName,
+                $pull['head']['sha']
+            );
+
+            $this->io->comment('Author: '.$pull['user']['login']);
+            $this->io->comment('Branch: '.$pull['base']['ref']);
+            $this->io->comment('Status: '.$state['state']);
+
+            // Ignore the PR is status is not good.
+            if ('success' !== $state['state']) {
+                continue;
+            }
+
+            $commits = $this->githubPaginator->fetchAll($this->githubClient->pullRequests(), 'commits', array(
+                static::GITHUB_GROUP,
+                $repositoryName,
+                $pull['number'],
+            ));
+
+            $commitMessages = array_map(function ($commit) {
+                return $commit['commit']['message'];
+            }, $commits);
+            $commitsCount = count($commitMessages);
+            $uniqueCommitsCount = count(array_unique($commitMessages));
+
+            // Some commit have the same message, but this cannot be squashed.
+            if ($commitsCount !== $uniqueCommitsCount && 1 !== $uniqueCommitsCount) {
+                $this->io->caution('This PR need a manual rebase.');
+                continue;
+            }
+            $squash = 1 === $uniqueCommitsCount;
+
+            $this->io->comment('Squash: '.($squash ? 'yes' : 'no'));
+
+            if ($this->apply) {
+                try {
+                    $this->githubClient->pullRequests()->merge(
+                        static::GITHUB_GROUP,
+                        $repositoryName,
+                        $pull['number'],
+                        $squash ? '' : $pull['title'],
+                        $pull['head']['sha'],
+                        $squash,
+                        $squash ? $commitMessages[0] : null
+                    );
+
+                    if ('sonata-project' === $pull['head']['repo']['owner']['login']) {
+                        $this->githubClient->gitData()->references()->remove(
+                            static::GITHUB_GROUP,
+                            $repositoryName,
+                            'heads/'.$pull['head']['ref']
+                        );
+                    }
+
+                    $this->io->success(sprintf('Merged PR #%d', $pull['number']));
+                } catch (ExceptionInterface $e) {
+                    $this->io->error('Failed with message: '.$e->getMessage());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Bots like StyleCI or SonataCI.

- [x] Check PR author (not commmit, PR).
- [x] Check if the targeted branch is managed by dev-kit. Do nothing otherwise.
- [x] Check if all service status are green. Even not required ones.
- [x] Try a merge, catch properly exception.
- ~~If fail because of updated PR, retry the process?~~
- [x] Manage commits: If one, do a squash, if many, do a merge commit
- [x] Manage bot commits: Squash them if all the same title (e.g. "DevKit updates"), do a merge commit if all differents, do nothing if some but not all commits are duplicates.
- [x] Manual test on **one** project.

Tell me if I'm missing something.

Partially concerns #81.

We need https://github.com/KnpLabs/php-github-api/pull/380 before merge.