### PR TITLE
Coveralls integration

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -64,3 +64,6 @@ before_script:
   - if [ -x .travis/before_script_${TARGET}.sh ]; then .travis/before_script_${TARGET}.sh; fi;
 
 script: make $TARGET
+
+after_success:
+  - if [ -x .travis/after_success_${TARGET}.sh ]; then .travis/after_success_${TARGET}.sh; fi;

--- a/project/.travis/after_success_test.sh
+++ b/project/.travis/after_success_test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -ev
+
+coveralls -v

--- a/project/.travis/install_test.sh
+++ b/project/.travis/install_test.sh
@@ -12,6 +12,10 @@ fi
 wget "https://phar.phpunit.de/${PHPUNIT_PHAR}" --output-document="${HOME}/bin/phpunit"
 chmod u+x "${HOME}/bin/phpunit"
 
+# Coveralls client install
+wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar --output-document="${HOME}/bin/coveralls"
+chmod u+x "${HOME}/bin/coveralls"
+
 # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
 if [ "${COMPOSER_FLAGS}" = '--prefer-lowest' ]; then
     composer update --prefer-dist --no-interaction --prefer-stable --quiet

--- a/project/Makefile
+++ b/project/Makefile
@@ -8,7 +8,7 @@ all:
 	@echo "Please choose a task."
 
 test:
-	phpunit -c phpunit.xml.dist
+	phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
 
 docs:
 	cd {{ docs_path }} && sphinx-build -W -b html -d _build/doctrees . _build/html

--- a/project/README.md
+++ b/project/README.md
@@ -10,9 +10,10 @@
 [![Monthly Downloads](https://poser.pugx.org/{{ packagist_name }}/d/monthly)](https://packagist.org/packages/{{ packagist_name }})
 [![Daily Downloads](https://poser.pugx.org/{{ packagist_name }}/d/daily)](https://packagist.org/packages/{{ packagist_name }})
 
-{{ stable_branch }} status: [![Build Status](https://travis-ci.org/sonata-project/{{ repository_name }}.svg?branch={{ stable_branch }})](https://travis-ci.org/sonata-project/{{ repository_name }})
-
-{{ unstable_branch }} status: [![Build Status](https://travis-ci.org/sonata-project/{{ repository_name }}.svg?branch={{ unstable_branch }})](https://travis-ci.org/sonata-project/{{ repository_name }})
+Branch | Travis | Coveralls |
+------ | ------ | --------- |
+{{ stable_branch }}   | [![Build Status][travis_stable_badge]][travis_stable_link]     | [![Coverage Status][coveralls_stable_badge]][coveralls_stable_link]     |
+{{ unstable_branch }} | [![Build Status][travis_unstable_badge]][travis_unstable_link] | [![Coverage Status][coveralls_unstable_badge]][coveralls_unstable_link] |
 
 ## Documentation
 
@@ -28,3 +29,13 @@ If you think you find a bug or you have a feature idea to propose, feel free to 
 ## License
 
 This package is available under the [MIT license](LICENSE).
+
+[travis_stable_badge]: https://travis-ci.org/sonata-project/{{ repository_name }}.svg?branch={{ stable_branch }}
+[travis_stable_link]: https://travis-ci.org/sonata-project/{{ repository_name }}
+[travis_unstable_badge]: https://travis-ci.org/sonata-project/{{ repository_name }}.svg?branch={{ unstable_branch }}
+[travis_unstable_link]: https://travis-ci.org/sonata-project/{{ repository_name }}
+
+[coveralls_stable_badge]: https://coveralls.io/repos/github/sonata-project/{{ repository_name }}/badge.svg?branch={{ stable_branch }}
+[coveralls_stable_link]: https://coveralls.io/github/sonata-project/{{ repository_name }}?branch={{ stable_branch }}
+[coveralls_unstable_badge]: https://coveralls.io/repos/github/sonata-project/{{ repository_name }}/badge.svg?branch={{ unstable_branch }}
+[coveralls_unstable_link]: https://coveralls.io/github/sonata-project/{{ repository_name }}?branch={{ unstable_branch }}


### PR DESCRIPTION
@sonata-project/contributors Please not that after that, any PR containing a code coverage decrease **must not** be accepted.

Instead, ask/help the contributors to fill missing tests.

We have enough not covered code, let start to not add more. :+1: 

Next step: Make coveralls status mandatory. If a PR as a bad coveralls status but must be accepted for some reason, ping @rande or me to force the merge.

Integration test: https://github.com/sonata-project/exporter/pull/98