### PR TITLE
Lint Travis job

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -37,6 +37,10 @@ matrix:
     - php: '{{ php|last }}'
       env: TARGET=docs
 {% endif %}
+{% if docs_target %}
+    - php: '{{ php|last }}'
+      env: TARGET=lint
+{% endif %}
     - php: '{{ php|first }}'
       env: COMPOSER_FLAGS="--prefer-lowest"
 {% for package_name,package_versions in versions %}

--- a/project/.travis/check_relevant_docs.sh
+++ b/project/.travis/check_relevant_docs.sh
@@ -3,4 +3,4 @@ set -ev
 
 RELEVANT_FILES=$(git diff --name-only HEAD upstream/${TRAVIS_BRANCH} -- '*.rst')
 
-if [[ -z  ${RELEVANT_FILES} ]];then echo -n 'KO'; exit 0; fi;
+if [[ -z ${RELEVANT_FILES} ]]; then echo -n 'KO'; exit 0; fi;

--- a/project/.travis/check_relevant_lint.sh
+++ b/project/.travis/check_relevant_lint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ev
+
+RELEVANT_FILES=$(git diff --name-only HEAD upstream/${TRAVIS_BRANCH} -- *.{json})
+
+if [[ -z ${RELEVANT_FILES} ]]; then echo -n 'KO'; exit 0; fi;

--- a/project/.travis/check_relevant_test.sh
+++ b/project/.travis/check_relevant_test.sh
@@ -3,4 +3,4 @@ set -ev
 
 RELEVANT_FILES=$(git diff --name-only HEAD upstream/${TRAVIS_BRANCH} -- *.{php,yml,xml,twig,js,css,json})
 
-if [[ -z  ${RELEVANT_FILES} ]];then echo -n 'KO'; exit 0; fi;
+if [[ -z ${RELEVANT_FILES} ]]; then echo -n 'KO'; exit 0; fi;

--- a/project/.travis/install_lint.sh
+++ b/project/.travis/install_lint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -ev
+
+composer global require sllh/composer-lint:@stable --prefer-dist --no-interaction

--- a/project/Makefile
+++ b/project/Makefile
@@ -7,6 +7,9 @@
 all:
 	@echo "Please choose a task."
 
+lint:
+	composer validate
+
 test:
 	phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
 


### PR DESCRIPTION
Introduce lint job. This job is to run lint check that can not be handle by bots like StyleCI.

The first introduced lint is the validation of composer with sllh/composer-lint plugin.

- [x] Test manually on a sonata project before merge
- [x] Rebase when #122 will be merged.