### PR TITLE
Launch travis target job only if relevant

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -28,6 +28,7 @@ env:
     - PATH="$HOME/.local/bin:$PATH"
     - SYMFONY_DEPRECATIONS_HELPER=weak
     - TARGET=test
+    - UPSTREAM_URL=https://github.com/sonata-project/{{ repository_name }}.git
 
 matrix:
   fast_finish: true
@@ -61,6 +62,9 @@ matrix:
 {% endfor %}
 
 before_install:
+  - git remote add upstream ${UPSTREAM_URL} && git fetch --all
+  - if [[ -x .travis/check_relevant_${TARGET}.sh && "$TRAVIS_PULL_REQUEST" != "false" ]]; then export RELEVANT=$(.travis/check_relevant_${TARGET}.sh); fi;
+  - if [[ ! -z ${RELEVANT} ]];then exit 0; fi;
   - if [ -x .travis/before_install_${TARGET}.sh ]; then .travis/before_install_${TARGET}.sh; fi;
 
 install:

--- a/project/.travis/check_relevant_docs.sh
+++ b/project/.travis/check_relevant_docs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ev
+
+RELEVANT_FILES=$(git diff --name-only HEAD upstream/${TRAVIS_BRANCH} -- '*.rst')
+
+if [[ -z  ${RELEVANT_FILES} ]];then echo -n 'KO'; exit 0; fi;

--- a/project/.travis/check_relevant_test.sh
+++ b/project/.travis/check_relevant_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ev
+
+RELEVANT_FILES=$(git diff --name-only HEAD upstream/${TRAVIS_BRANCH} -- *.{php,yml,xml,twig,js,css,json})
+
+if [[ -z  ${RELEVANT_FILES} ]];then echo -n 'KO'; exit 0; fi;

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -340,7 +340,8 @@ final class DispatchCommand extends AbstractNeedApplyCommand
             file_put_contents($distPath, $this->twig->render($localPath, array_merge(
                 $this->configs,
                 $projectConfig,
-                $branchConfig
+                $branchConfig,
+                array('repository_name' => $repositoryName)
             )));
         } else {
             reset($projectConfig['branches']);


### PR DESCRIPTION
Closes #118 

If no relevant file is present on a PR, the job will directly exit with sucess.

This is not applicable on main branches.

Working Travis example: https://travis-ci.org/Soullivaneuh/sonata-exporter/jobs/134142056#L195

Related PR: https://github.com/Soullivaneuh/sonata-exporter/pull/1