### PR TITLE
Add pedantic label

### DIFF
--- a/config/dev-kit.yml
+++ b/config/dev-kit.yml
@@ -5,6 +5,8 @@ labels:
     color: '009800'
   - name: major
     color: 'e11d21'
+  - name: pedantic
+    color: 'd1e4fa'
   - name: bug
     color: 'fc2929'
   - name: critical


### PR DESCRIPTION
This label will be used on PRs concerning change not related to any patch, minor or major tag.

This can concerns PRs about typos, coding style or whatever that does not affect the code working itself.

Please note that PRs about documentation already have the `docs` label. Do not use `pedantic` on them.

PRs with `docs` or `pedantic` labels should not have a changelog.

If anyone have a better suggestion, feel free to comment! :+1: 

cc @sonata-project/contributors 