### PR TITLE
Yaml linter

### DIFF
--- a/project/.travis/check_relevant_lint.sh
+++ b/project/.travis/check_relevant_lint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ev
 
-RELEVANT_FILES=$(git diff --name-only HEAD upstream/${TRAVIS_BRANCH} -- *.{json})
+RELEVANT_FILES=$(git diff --name-only HEAD upstream/${TRAVIS_BRANCH} -- '*.json' '*.yml')
 
 if [[ -z ${RELEVANT_FILES} ]]; then echo -n 'KO'; exit 0; fi;

--- a/project/.travis/install_lint.sh
+++ b/project/.travis/install_lint.sh
@@ -2,3 +2,5 @@
 set -ev
 
 composer global require sllh/composer-lint:@stable --prefer-dist --no-interaction
+
+gem install yaml-lint

--- a/project/Makefile
+++ b/project/Makefile
@@ -9,6 +9,7 @@ all:
 
 lint:
 	composer validate
+	find . -name '*.yml' -not -path './vendor/*' | xargs yaml-lint
 
 test:
 	phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml


### PR DESCRIPTION
This linter use `yaml-lint` gem: https://github.com/Pryz/yaml-lint

This tools will prevent yaml syntax errors with more accurate than Symfony. Especially for SF 2.x versions.

Working Travis job: https://travis-ci.org/sonata-project/SonataTranslationBundle/jobs/135815943#L216