### PR TITLE
Request people to use SO for questions more firmly

### DIFF
--- a/project/CONTRIBUTING.md
+++ b/project/CONTRIBUTING.md
@@ -13,8 +13,11 @@ Thanks for your interest in Sonata projects!
 First, check if you are up to date: is your version still supported, and are
 you using the latest patch version?
 
-If you are not sure this is a bug, consider posting your question on [Stack
-Overflow](http://stackoverflow.com), using one of the sonata tags.
+GitHub Issues is for **issues**, as opposed to question on how to use Sonata.
+If you are not sure this is a bug, or simply want to ask such a question,
+please post your question on [Stack Overflow](http://stackoverflow.com/questions/tagged/sonata),
+using the `sonata` tags.
+
 If you happen to find a bug, we kindly request you report it. However,
 before submitting it, please check the [project documentation available
 online](https://sonata-project.org/bundles/).


### PR DESCRIPTION
We now watch SO on slack, so there is no real reason to tolerate
questions on the issue tracker anymore.