### PR TITLE
Remove GitHub API auth from Travis

### DIFF
--- a/project/.travis/before_install_test.sh.twig
+++ b/project/.travis/before_install_test.sh.twig
@@ -12,7 +12,6 @@ fi
 
 # To be removed when following PR will be merged: https://github.com/travis-ci/travis-build/pull/718
 composer self-update --stable
-composer config --quiet --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
 sed --in-place "s/\"dev-master\":/\"dev-${TRAVIS_COMMIT}\":/" composer.json
 
 {% for package_name,package_versions in versions if package_versions|length > 0 %}


### PR DESCRIPTION
This is not needed anymore as GitHub removed API limits for archive download.

Ref: https://github.com/composer/composer/issues/4884#issuecomment-195229989

Thanks @theofidry for the hint! :+1: :heart: 