### PR TITLE
Request explanation for targetted branch

### DIFF
--- a/project/.github/PULL_REQUEST_TEMPLATE.md
+++ b/project/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,15 @@
 <!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->
 
 <!--
+    Show us you choose the right branch.
+    Different branches are used for different things :
+    - {{ stable_branch }} is for everything backwards compatible, like patches, features and deprecation notices
+    - {{ unstable_branch }} is for deprecation removals and other changes that cannot be done without a BC-break
+    More details here: https://github.com/sonata-project/{{ repository_name }}/blob/{{ current_branch }}/CONTRIBUTING.md#the-base-branch
+-->
+I am targetting this branch, because…
+
+<!--
     Specify which issues will be fixed/closed.
     Remove it if this is not related.
 -->


### PR DESCRIPTION
This should save everyone a lot of time :

- Contributors targetting the wrong branch will realize their mistake
  before making it, or at least explain why they think they are right.
- Contributors that don't understand which branch they should target
  will say it.
- Contributors that don't care will be noticed.
- This will be one less thing to think about for reviewers.