### PR TITLE
Removed unstable branch for dashboard-bundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -108,13 +108,6 @@ dashboard-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
-    0.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
-      versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
-        sonata_core: ['3']
-        sonata_admin: ['3']
-        sonata_block: ['3']
 
 datagrid-bundle:
   branches:


### PR DESCRIPTION
As long as we don't have a stable release, we could use the master branch for development. 

We are <1.0, so we can't have any BC break, which would justify a separate branch.