### PR TITLE
Bump PHP versions tests to 5.6

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -1,7 +1,7 @@
 admin-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -18,7 +18,7 @@ admin-search-bundle:
     - README.md
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         sonata_admin: ['3']
@@ -27,7 +27,7 @@ admin-search-bundle:
 block-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -47,14 +47,14 @@ cache:
   docs_target: false
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
 
 cache-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
     2.x:
@@ -65,7 +65,7 @@ cache-bundle:
 classification-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_admin: ['3']
@@ -78,7 +78,7 @@ classification-bundle:
 comment-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         sonata_core: ['3']
@@ -91,7 +91,7 @@ comment-bundle:
 core-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
     3.x:
@@ -102,7 +102,7 @@ core-bundle:
 dashboard-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -112,7 +112,7 @@ dashboard-bundle:
 datagrid-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
     2.x:
@@ -126,14 +126,14 @@ doctrine-extensions:
   docs_target: false
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
 
 doctrine-mongodb-admin-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6']
+      php: ['5.6']
       services: [mongodb]
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
@@ -148,7 +148,7 @@ doctrine-mongodb-admin-bundle:
 doctrine-orm-admin-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -163,7 +163,7 @@ doctrine-orm-admin-bundle:
 doctrine-phpcr-admin-bundle:
   branches:
     master:
-      php: ['5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_admin: ['3']
@@ -178,7 +178,7 @@ doctrine-phpcr-admin-bundle:
 easy-extends-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
     2.x:
@@ -193,7 +193,7 @@ exporter:
     - README.md
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       target_php: 5.6
       versions:
         symfony: ['2.8', '3.0', '3.1']
@@ -210,7 +210,7 @@ exporter:
 formatter-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -228,14 +228,14 @@ google-authenticator:
   docs_target: false
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
 
 intl-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_user: ['2', '3']
@@ -248,7 +248,7 @@ intl-bundle:
 media-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       target_php: 5.6
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
@@ -267,7 +267,7 @@ media-bundle:
 news-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         sonata_core: ['3']
@@ -284,7 +284,7 @@ news-bundle:
 notification-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -297,7 +297,7 @@ notification-bundle:
 page-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         sonata_core: ['3']
@@ -318,7 +318,7 @@ sandbox: ~
 seo-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_block: ['3']
@@ -333,7 +333,7 @@ seo-bundle:
 timeline-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -365,7 +365,7 @@ translation-bundle:
 user-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.6', '7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         fos_user: ['1.3']


### PR DESCRIPTION
Closes #52.

This will update Travis config **only**. Modifications have to be made on the `composer.json` of each project too.

@sonata-project/contributors If you have any suggestion/question, feel free! :+1: 