### PR TITLE
Add mongodb adapter to mongo build

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -138,13 +138,13 @@ doctrine-extensions:
 doctrine-mongodb-admin-bundle:
   branches:
     master:
-      php: ['5.6']
+      php: ['5.6', '7.0']
       services: [mongodb]
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_admin: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6']
+      php: ['5.6', '7.0']
       services: [mongodb]
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']

--- a/project/.travis/before_install_test.sh.twig
+++ b/project/.travis/before_install_test.sh.twig
@@ -14,6 +14,13 @@ fi
 composer self-update --stable
 sed --in-place "s/\"dev-master\":/\"dev-${TRAVIS_COMMIT}\":/" composer.json
 
+
+if [ ${TRAVIS_PHP_VERSION} '>=' '7.0' ]; then
+    {% if 'mongodb' in services %}
+    pecl install --force mongodb-stable
+    composer require "alcaeus/mongo-php-adapter" --ignore-platform-reqs --no-update
+    {% endif %}
+fi
 {% for package_name,package_versions in versions if package_versions|length > 0 %}
 if [ "${{ package_name|upper }}" != "" ]; then composer require "{{ packages[package_name] }}:${{ package_name|upper }}" --no-update; fi;
 {% endfor %}


### PR DESCRIPTION
Use mongodb adapter in related builds

Related to https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/183
Fixes https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/186

PS I didn't check that it is working properly. Could you?
