### PR TITLE
Converts ::class keywords to FQCN strings

### DIFF
--- a/project/.styleci.yml
+++ b/project/.styleci.yml
@@ -7,6 +7,7 @@
 preset: symfony
 
 enabled:
+  - class_keyword_remove
   - combine_consecutive_unsets
   - long_array_syntax
   - newline_after_open_tag


### PR DESCRIPTION
Updates the `.styleci.yml` config to convert all `::class` to strings.