### PR TITLE
Drop support for Symfony 3.0.x

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -3,13 +3,13 @@ admin-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -27,21 +27,21 @@ article-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
 
 block-bundle:
   branches:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_core: ['3']
         # https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/131844587#L222
         #sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_core: ['3']
         # This has to be resolved: https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/130298942#L230
         #sonata_admin: ['3']
@@ -61,23 +61,23 @@ cache-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
 
 classification-bundle:
   branches:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_admin: ['3']
 
 comment-bundle:
@@ -98,18 +98,18 @@ core-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
 
 dashboard-bundle:
   branches:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
@@ -119,11 +119,11 @@ datagrid-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
 
 doctrine-extensions:
   excluded_files:
@@ -141,13 +141,13 @@ doctrine-mongodb-admin-bundle:
       php: ['5.6']
       services: [mongodb]
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6']
       services: [mongodb]
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_admin: ['3']
 
 doctrine-orm-admin-bundle:
@@ -155,13 +155,13 @@ doctrine-orm-admin-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
 
@@ -170,7 +170,7 @@ doctrine-phpcr-admin-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_admin: ['3']
         sonata_block: ['3']
     1.x:
@@ -185,11 +185,11 @@ easy-extends-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
 
 ecommerce:
   branches:
@@ -212,14 +212,14 @@ exporter:
       php: ['5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         doctrine_odm: ['1']
       docs_path: docs
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         doctrine_odm: ['1']
       docs_path: docs
 
@@ -228,13 +228,13 @@ formatter-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -253,12 +253,12 @@ intl-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_user: ['2', '3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_user: ['2', '3']
 
 media-bundle:
@@ -267,7 +267,7 @@ media-bundle:
       php: ['5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
@@ -275,7 +275,7 @@ media-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
@@ -302,12 +302,12 @@ notification-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_core: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_core: ['3']
 
 page-bundle:
@@ -336,13 +336,13 @@ seo-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_block: ['3']
         sonata_admin: ['3']
 
@@ -351,14 +351,14 @@ timeline-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
@@ -368,13 +368,13 @@ translation-bundle:
     master:
       php: ['5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
 

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -3,13 +3,13 @@ admin-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -27,21 +27,21 @@ article-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
 
 block-bundle:
   branches:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_core: ['3']
         # https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/131844587#L222
         #sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_core: ['3']
         # This has to be resolved: https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/130298942#L230
         #sonata_admin: ['3']
@@ -61,23 +61,23 @@ cache-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
 
 classification-bundle:
   branches:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_admin: ['3']
 
 comment-bundle:
@@ -98,18 +98,18 @@ core-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
 
 dashboard-bundle:
   branches:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
@@ -119,11 +119,11 @@ datagrid-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
 
 doctrine-extensions:
   excluded_files:
@@ -141,13 +141,13 @@ doctrine-mongodb-admin-bundle:
       php: ['5.6']
       services: [mongodb]
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6']
       services: [mongodb]
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_admin: ['3']
 
 doctrine-orm-admin-bundle:
@@ -155,13 +155,13 @@ doctrine-orm-admin-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_admin: ['3']
 
@@ -170,7 +170,7 @@ doctrine-phpcr-admin-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_admin: ['3']
         sonata_block: ['3']
     1.x:
@@ -185,11 +185,11 @@ easy-extends-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
 
 ecommerce:
   branches:
@@ -212,14 +212,14 @@ exporter:
       php: ['5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         doctrine_odm: ['1']
       docs_path: docs
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         doctrine_odm: ['1']
       docs_path: docs
 
@@ -228,13 +228,13 @@ formatter-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -253,12 +253,12 @@ intl-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_user: ['2', '3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_user: ['2', '3']
 
 media-bundle:
@@ -267,7 +267,7 @@ media-bundle:
       php: ['5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
@@ -275,7 +275,7 @@ media-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
@@ -302,12 +302,12 @@ notification-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_core: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_core: ['3']
 
 page-bundle:
@@ -336,13 +336,13 @@ seo-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_block: ['3']
         sonata_admin: ['3']
 
@@ -351,14 +351,14 @@ timeline-bundle:
     master:
       php: ['5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
@@ -368,13 +368,13 @@ translation-bundle:
     master:
       php: ['5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.8', '3.1']
+        symfony: ['2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         sonata_core: ['3']
         sonata_admin: ['3']
 


### PR DESCRIPTION
See https://symfony.com/roadmap?version=3.0#checker
bugfix support has ended, security support will end soon.
Refs https://github.com/sonata-project/SonataCoreBundle/pull/371