### PR TITLE
Drop php5

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -1,7 +1,7 @@
 admin-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -16,7 +16,7 @@ admin-bundle:
 admin-search-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8']
         sonata_admin: ['3']
@@ -25,14 +25,14 @@ admin-search-bundle:
 article-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
 
 block-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -52,14 +52,14 @@ cache:
   docs_target: false
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
 
 cache-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
     2.x:
@@ -70,7 +70,7 @@ cache-bundle:
 classification-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_admin: ['3']
@@ -83,7 +83,7 @@ classification-bundle:
 comment-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
@@ -96,7 +96,7 @@ comment-bundle:
 core-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
     3.x:
@@ -107,7 +107,7 @@ core-bundle:
 dashboard-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -117,7 +117,7 @@ dashboard-bundle:
 datagrid-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
     2.x:
@@ -131,7 +131,7 @@ doctrine-extensions:
   docs_target: false
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
 
@@ -153,7 +153,7 @@ doctrine-mongodb-admin-bundle:
 doctrine-orm-admin-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -168,7 +168,7 @@ doctrine-orm-admin-bundle:
 doctrine-phpcr-admin-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_admin: ['3']
@@ -183,7 +183,7 @@ doctrine-phpcr-admin-bundle:
 easy-extends-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
     2.x:
@@ -194,7 +194,7 @@ easy-extends-bundle:
 ecommerce:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8']
       docs_path: docs
@@ -209,8 +209,7 @@ exporter:
     - README.md
   branches:
     master:
-      php: ['5.6', '7.0']
-      target_php: 5.6
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         doctrine_odm: ['1']
@@ -226,7 +225,7 @@ exporter:
 formatter-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -244,14 +243,14 @@ google-authenticator:
   docs_target: false
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
 
 intl-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_user: ['2', '3']
@@ -264,8 +263,7 @@ intl-bundle:
 media-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
-      target_php: 5.6
+      php: ['7.0']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         doctrine_odm: ['1']
@@ -283,7 +281,7 @@ media-bundle:
 news-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
@@ -300,7 +298,7 @@ news-bundle:
 notification-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -313,7 +311,7 @@ notification-bundle:
 page-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
@@ -334,7 +332,7 @@ sandbox: ~
 seo-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_block: ['3']
@@ -349,7 +347,7 @@ seo-bundle:
 timeline-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -366,7 +364,7 @@ timeline-bundle:
 translation-bundle:
   branches:
     master:
-      php: ['5.4', '5.5', '5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -381,7 +379,7 @@ translation-bundle:
 user-bundle:
   branches:
     master:
-      php: ['5.6', '7.0']
+      php: ['7.0']
       versions:
         symfony: ['2.8']
         fos_user: ['1.3']

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -1,13 +1,13 @@
 admin-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -16,7 +16,7 @@ admin-bundle:
 admin-search-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8']
         sonata_admin: ['3']
@@ -25,21 +25,21 @@ admin-search-bundle:
 article-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
 
 block-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
         # https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/131844587#L222
         #sonata_admin: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -52,30 +52,30 @@ cache:
   docs_target: false
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
     1.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
 
 cache-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
     2.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
 
 classification-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_admin: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_admin: ['3']
@@ -83,12 +83,12 @@ classification-bundle:
 comment-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         sonata_core: ['3']
@@ -96,18 +96,18 @@ comment-bundle:
 core-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
 
 dashboard-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -117,11 +117,11 @@ dashboard-bundle:
 datagrid-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
     2.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
 
@@ -131,9 +131,9 @@ doctrine-extensions:
   docs_target: false
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
     1.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
 
 doctrine-mongodb-admin-bundle:
   branches:
@@ -153,13 +153,13 @@ doctrine-mongodb-admin-bundle:
 doctrine-orm-admin-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -168,13 +168,13 @@ doctrine-orm-admin-bundle:
 doctrine-phpcr-admin-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_admin: ['3']
         sonata_block: ['3']
     1.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         sonata_admin: ['2']
@@ -183,23 +183,23 @@ doctrine-phpcr-admin-bundle:
 easy-extends-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
     2.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
 
 ecommerce:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8']
       docs_path: docs
     2.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8']
       docs_path: docs
@@ -209,13 +209,13 @@ exporter:
     - README.md
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         doctrine_odm: ['1']
       docs_path: docs
     1.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       target_php: 5.6
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
@@ -225,13 +225,13 @@ exporter:
 formatter-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -243,19 +243,19 @@ google-authenticator:
   docs_target: false
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
     1.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
 
 intl-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_user: ['2', '3']
     2.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_user: ['2', '3']
@@ -263,14 +263,14 @@ intl-bundle:
 media-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       target_php: 5.6
       versions:
         symfony: ['2.8', '3.0', '3.1']
@@ -281,14 +281,14 @@ media-bundle:
 news-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_user: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         sonata_core: ['3']
@@ -298,12 +298,12 @@ news-bundle:
 notification-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -311,14 +311,14 @@ notification-bundle:
 page-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         sonata_core: ['3']
@@ -332,13 +332,13 @@ sandbox: ~
 seo-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_block: ['3']
@@ -347,14 +347,14 @@ seo-bundle:
 timeline-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -364,13 +364,13 @@ timeline-bundle:
 translation-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8', '3.0', '3.1']
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['5.4', '5.5', '5.6', '7.0']
+      php: ['5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
         sonata_core: ['3']
@@ -379,14 +379,14 @@ translation-bundle:
 user-bundle:
   branches:
     master:
-      php: ['7.0']
+      php: ['7.0', '7.1']
       versions:
         symfony: ['2.8']
         fos_user: ['1.3']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8']
         fos_user: ['1.3']


### PR DESCRIPTION
Based on the [twitter vote](https://twitter.com/core23de/status/817044245018185728), we could drop PHP5 completly for the next majors.