### PR TITLE
show only on line if stable and unstable branch are equal

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -13,7 +13,9 @@
 Branch | Travis | Coveralls |
 ------ | ------ | --------- |
 {{ stable_branch }}   | [![Build Status][travis_stable_badge]][travis_stable_link]     | [![Coverage Status][coveralls_stable_badge]][coveralls_stable_link]     |
-{{ unstable_branch }} | [![Build Status][travis_unstable_badge]][travis_unstable_link] | [![Coverage Status][coveralls_unstable_badge]][coveralls_unstable_link] |
+{% if unstable_branch != stable_branch %}
+    {{ unstable_branch }} | [![Build Status][travis_unstable_badge]][travis_unstable_link] | [![Coverage Status][coveralls_unstable_badge]][coveralls_unstable_link] |
+{% endif %}
 
 ## Documentation
 


### PR DESCRIPTION
We show the same branch twice in SonataAdminSearchBundle:

![bildschirmfoto 2017-01-17 um 11 06 03](https://cloud.githubusercontent.com/assets/995707/22016403/755c2700-dca6-11e6-9857-ab74e47aa5a4.png)
