### PR TITLE
Stop testing old versions of Symfony

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -196,7 +196,7 @@ ecommerce:
     master:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8']
+        symfony: ['2.8']
       docs_path: docs
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
@@ -267,7 +267,7 @@ media-bundle:
       php: ['5.6', '7.0']
       target_php: 5.6
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']


### PR DESCRIPTION
Looks like this was overlooked, it should have been done in #154 

Prompted by https://github.com/sonata-project/SonataMediaBundle/pull/1179