### PR TITLE
sonata phpcr-odm admin 2 still supports php 5.6

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -174,7 +174,8 @@ doctrine-orm-admin-bundle:
 doctrine-phpcr-admin-bundle:
   branches:
     master:
-      php: ['7.0', '7.1']
+      # sonata 2 should still support php 5.6 to be consistent with the symfony cmf
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.1', '3.2']
         sonata_admin: ['3']


### PR DESCRIPTION
according to the composer.json, sonata phpcr-odm still supports php 5 versions. cmf 2.0 is going for php 5.6. i would like to do the same with the sonata admin, if that makes sense.

we rely on admin-bundle ^3.1 - it looks like that allows anything from php 5.3 and 7, so should work out, right?