### PR TITLE
Fix wrong configuration of media-bundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -280,6 +280,7 @@ media-bundle:
   branches:
     master:
       php: ['7.1']
+      services: [mongodb]
       versions:
         symfony: ['2.8', '3.1', '3.2']
         doctrine_odm: ['1']
@@ -287,9 +288,9 @@ media-bundle:
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
-      target_php: 5.6
+      services: [mongodb]
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']


### PR DESCRIPTION
There is no need to block php on 5.6 on 3.x, test should pass on 7.1. 

Added mongodb as service since it is required by doctrine-odm on PHP 7.0+ (not sure we want to keep that build tho). https://travis-ci.org/sonata-project/SonataMediaBundle/jobs/204407963

Bring back Symfony 2.3 and 2.7 to 3.x. this is blocked until https://github.com/sonata-project/SonataMediaBundle/pull/1209 gets merged
