### PR TITLE
Add mongodb to PHP7 with ext-mongo compatibility

### DIFF
--- a/project/.travis/before_install_test.sh.twig
+++ b/project/.travis/before_install_test.sh.twig
@@ -6,9 +6,16 @@ if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then
     TRAVIS_INI_FILE="$PHP_INI_DIR/travis.ini"
     echo "memory_limit=3072M" >> "$TRAVIS_INI_FILE"
 
+    {% if 'mongodb' in services %}
     if [ "$TRAVIS_PHP_VERSION" '<' '7.0' ]; then
         echo "extension=mongo.so" >> "$TRAVIS_INI_FILE"
+    else
+        echo "extension=mongodb.so" >> "$TRAVIS_INI_FILE"
+
+        # Backwards compatibility with old mongo extension
+        composer require "alcaeus/mongo-php-adapter" --no-update
     fi
+    {% endif %}
 fi
 
 # To be removed when following PR will be merged: https://github.com/travis-ci/travis-build/pull/718

--- a/project/.travis/install_test.sh
+++ b/project/.travis/install_test.sh
@@ -16,8 +16,9 @@ chmod u+x "${HOME}/bin/phpunit"
 wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar --output-document="${HOME}/bin/coveralls"
 chmod u+x "${HOME}/bin/coveralls"
 
-# To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-if [ "${COMPOSER_FLAGS}" = '--prefer-lowest' ]; then
-    composer update --prefer-dist --no-interaction --prefer-stable --quiet
-fi
+# To be removed when these issues are resolved:
+# https://github.com/composer/composer/issues/5355
+# https://github.com/composer/composer/issues/5030
+composer update --prefer-dist --no-interaction --prefer-stable --quiet --ignore-platform-reqs
+
 travis_wait composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}


### PR DESCRIPTION
Add mongodb extension to PHP7. With compatibility with old ext-mongo.

There are two issues that need to run a previous composer update to create composer.lock in order to not fail installing with correct composer flags.

https://github.com/composer/composer/issues/5355 that shows when using `prefer-lowest`
https://github.com/composer/composer/issues/5030 when using packages that provides extension implementations like: alcaeus/mongo-php-adapter

This is needed to start moving to PHP7.0 in our builds and can also be used to stop testing on PHP5.6 on 3.x branches.

There is a little overhead when running always two times composer update, but is not that big. Only if you are running PHP < 7, but still not that big difference.

This PR shows an example on media-bundle: https://github.com/sonata-project/SonataMediaBundle/pull/1211

Closes https://github.com/sonata-project/dev-kit/pull/192