### PR TITLE
Remove composer self update from travis build process

### DIFF
--- a/project/.travis/before_install_test.sh.twig
+++ b/project/.travis/before_install_test.sh.twig
@@ -10,8 +10,6 @@ if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then
     fi
 fi
 
-# To be removed when following PR will be merged: https://github.com/travis-ci/travis-build/pull/718
-composer self-update --stable
 sed --in-place "s/\"dev-master\":/\"dev-${TRAVIS_COMMIT}\":/" composer.json
 
 {% for package_name,package_versions in versions if package_versions|length > 0 %}


### PR DESCRIPTION
This PR (https://github.com/travis-ci/travis-build/pull/718) is not merged yet, but the issue is solved now, you can see it here:

https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/php.rb#L165

And on every travis build, there is a triple composer update actually, two of them comes from travis itself and the last one is from us, those lines are no longer needed.