### PR TITLE
removed obsolete labels

### DIFF
--- a/config/dev-kit.yml
+++ b/config/dev-kit.yml
@@ -23,12 +23,8 @@ labels:
     color: 'ededed'
   - name: in progress
     color: 'ededed'
-  - name: RTM
-    color: 'ffffff'
   - name: docs
     color: 'fbca04'
-  - name: review required
-    color: 'd4c5f9'
   - name: help wanted
     color: '0e8a16'
   - name: Easy Pick


### PR DESCRIPTION
removed "review required" and "RTM" label, as github now provides a better workflow to handle PR's