### PR TITLE
StyleCI: Ignore assets from vendors

### DIFF
--- a/project/.styleci.yml
+++ b/project/.styleci.yml
@@ -26,3 +26,5 @@ finder:
     - 'Tests/Fixtures'
     # ecommerce special case:
     - 'Resources/skeleton'
+    # ignore vendor assets
+    - 'Resources/public/vendor'


### PR DESCRIPTION
We shouldn't fix assets from vendors when running StyleCI.

Refs. https://github.com/sonata-project/SonataFormatterBundle/pull/255