### PR TITLE
use trusty for hhvm build

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -15,7 +15,6 @@ php:
   - '{{ version }}'
 {% endfor %}
   - nightly
-  - hhvm
 
 {% if services is not empty %}
 services:
@@ -64,6 +63,8 @@ matrix:
 {% endfor %}
     - php: '{{ php|last }}'
       env: SYMFONY_DEPRECATIONS_HELPER=0
+    - php: hhvm
+      dist: trusty
   allow_failures:
     - php: nightly
     - php: hhvm


### PR DESCRIPTION
because we allow failures, the problem was hidden. since a while travis-ci can't do hhvm on the default distribution anymore and outputs a message to use trusty instead.