### PR TITLE
lowest version build for phpcr-odm admin takes longer than 10 minutes

### DIFF
--- a/project/.travis/install_test.sh
+++ b/project/.travis/install_test.sh
@@ -20,4 +20,4 @@ chmod u+x "${HOME}/bin/coveralls"
 if [ "${COMPOSER_FLAGS}" = '--prefer-lowest' ]; then
     composer update --prefer-dist --no-interaction --prefer-stable --quiet
 fi
-composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}
+travis_wait composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}


### PR DESCRIPTION
as found in https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/446 we do need the wait. on normal operation it should not hurt to have it.