### PR TITLE
Remove deprecated versions of sonata_user from SonataIntlBundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -269,12 +269,12 @@ intl-bundle:
       php: ['7.1']
       versions:
         symfony: ['2.8', '3.1', '3.2']
-        sonata_user: ['2', '3']
+        sonata_user: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
-        sonata_user: ['2', '3']
+        sonata_user: ['3']
 
 media-bundle:
   branches:


### PR DESCRIPTION
We are building IntlBundle with SonataUser 2.* which is deprecated and on the conflict section of composer.json.