### PR TITLE
Drop outdated versions for dashboard bundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -122,7 +122,7 @@ dashboard-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['3.1', '3.2']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']


### PR DESCRIPTION
We have no stable release yet for this bundle and should only support the latest supported versions for php and symfony.

Refs: https://github.com/sonata-project/SonataDashboardBundle/pull/82