### PR TITLE
Stop testing phpcr 1.x with Sonata 3.

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -191,8 +191,6 @@ doctrine-phpcr-admin-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
         symfony: ['2.3', '2.7', '2.8']
-        sonata_admin: ['3']
-        sonata_block: ['3']
 
 easy-extends-bundle:
   branches:


### PR DESCRIPTION
Version 1.x of this bundle does not support Sonata 3, and Sonata 2 is
already tested in the regular builds.