### PR TITLE
Add Symfony 3.3 to testing versions for all bundles tested against Symfony 3.x

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -3,13 +3,13 @@ admin-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -33,21 +33,21 @@ article-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
 
 block-bundle:
   branches:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         # https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/131844587#L222
         #sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         # This has to be resolved: https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/130298942#L230
         #sonata_admin: ['3']
@@ -67,23 +67,23 @@ cache-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
 
 classification-bundle:
   branches:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_admin: ['3']
 
 classification-media-bundle:
@@ -111,18 +111,18 @@ core-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
 
 dashboard-bundle:
   branches:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
@@ -132,11 +132,11 @@ datagrid-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
 
 doctrine-extensions:
   excluded_files:
@@ -154,13 +154,13 @@ doctrine-mongodb-admin-bundle:
       php: ['5.6']
       services: [mongodb]
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6']
       services: [mongodb]
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_admin: ['3']
 
 doctrine-orm-admin-bundle:
@@ -168,13 +168,13 @@ doctrine-orm-admin-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
 
@@ -184,7 +184,7 @@ doctrine-phpcr-admin-bundle:
       # sonata 2 should still support php 5.6 to be consistent with the symfony cmf
       php: ['5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_admin: ['3']
         sonata_block: ['3']
     1.x:
@@ -199,11 +199,11 @@ easy-extends-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
 
 ecommerce:
   branches:
@@ -225,14 +225,14 @@ exporter:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         doctrine_odm: ['1']
       docs_path: docs
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       target_php: 5.6
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         doctrine_odm: ['1']
       docs_path: docs
 
@@ -241,13 +241,13 @@ formatter-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -268,12 +268,12 @@ intl-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_user: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_user: ['3']
 
 media-bundle:
@@ -282,7 +282,7 @@ media-bundle:
       php: ['7.1']
       services: [mongodb]
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
@@ -290,7 +290,7 @@ media-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       services: [mongodb]
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
@@ -317,12 +317,12 @@ notification-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
 
 page-bundle:
@@ -351,13 +351,13 @@ seo-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_block: ['3']
         sonata_admin: ['3']
 
@@ -366,14 +366,14 @@ timeline-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
@@ -383,13 +383,13 @@ translation-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
+        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
 
@@ -398,7 +398,7 @@ user-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2']
+        symfony: ['2.8', '3.1', '3.2', '3.3']
         fos_user: ['2']
         sonata_core: ['3']
         sonata_admin: ['3']

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -3,13 +3,13 @@ admin-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -33,21 +33,21 @@ article-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
 
 block-bundle:
   branches:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         # https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/131844587#L222
         #sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_core: ['3']
         # This has to be resolved: https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/130298942#L230
         #sonata_admin: ['3']
@@ -67,23 +67,23 @@ cache-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
 
 classification-bundle:
   branches:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_admin: ['3']
 
 classification-media-bundle:
@@ -91,7 +91,7 @@ classification-media-bundle:
     master:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
 
 comment-bundle:
   branches:
@@ -111,18 +111,18 @@ core-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
 
 dashboard-bundle:
   branches:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
@@ -132,11 +132,11 @@ datagrid-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
 
 doctrine-extensions:
   excluded_files:
@@ -154,13 +154,13 @@ doctrine-mongodb-admin-bundle:
       php: ['5.6']
       services: [mongodb]
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6']
       services: [mongodb]
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_admin: ['3']
 
 doctrine-orm-admin-bundle:
@@ -168,13 +168,13 @@ doctrine-orm-admin-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
 
@@ -184,7 +184,7 @@ doctrine-phpcr-admin-bundle:
       # sonata 2 should still support php 5.6 to be consistent with the symfony cmf
       php: ['5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_admin: ['3']
         sonata_block: ['3']
     1.x:
@@ -199,11 +199,11 @@ easy-extends-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
 
 ecommerce:
   branches:
@@ -225,14 +225,14 @@ exporter:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         doctrine_odm: ['1']
       docs_path: docs
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       target_php: 5.6
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         doctrine_odm: ['1']
       docs_path: docs
 
@@ -241,13 +241,13 @@ formatter-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_block: ['3']
 
@@ -268,12 +268,12 @@ intl-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_user: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_user: ['3']
 
 media-bundle:
@@ -282,7 +282,7 @@ media-bundle:
       php: ['7.1']
       services: [mongodb]
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
@@ -290,7 +290,7 @@ media-bundle:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       services: [mongodb]
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         doctrine_odm: ['1']
         sonata_core: ['3']
         sonata_admin: ['3']
@@ -317,12 +317,12 @@ notification-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_core: ['3']
 
 page-bundle:
@@ -351,13 +351,13 @@ seo-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_block: ['3']
         sonata_admin: ['3']
 
@@ -366,14 +366,14 @@ timeline-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
@@ -383,13 +383,13 @@ translation-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['5.4', '5.5', '5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.3', '2.7', '2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
 
@@ -398,7 +398,7 @@ user-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8', '3.1', '3.2', '3.3']
+        symfony: ['2.8', '3.2', '3.3']
         fos_user: ['2']
         sonata_core: ['3']
         sonata_admin: ['3']


### PR DESCRIPTION
Symfony 3.3 is the current stable release but the CI tests aren't run on it in any of the bundles yet. This PR adds it to the Symfony version list for all bundles which are currently tested on other 3.x versions.