### PR TITLE
Require precise

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -24,6 +24,7 @@ services:
 
 {% endif %}
 sudo: false
+dist: precise
 
 cache:
   pip: true


### PR DESCRIPTION
The trusty Travis image cannot run php 5.3, because, you know, it is EOL
since 2014. This is a quick fix, but maybe we should amend our policy of
not dropping support for minor versions of php to include an exception
for versions that are no longer maintained.

https://github.com/travis-ci/travis-ci/issues/2963
https://secure.php.net/supported-versions.php

Proof PR: https://github.com/sonata-project/SonataAdminBundle/pull/4612