### PR TITLE
Add specific instructions for Mac OS users

### DIFF
--- a/project/CONTRIBUTING.md
+++ b/project/CONTRIBUTING.md
@@ -83,7 +83,7 @@ To get sphinx, simply run the following command.
 pip install --requirement {{ docs_path }}/requirements.txt --user
 ```
 
-Some python binaries should be downloaded in `~/.local/bin`,
+Some python binaries should be downloaded to `~/.local/bin` for Linux or `~/Library/Python/2.7/bin` for Mac OS,
 [modify your `$PATH` environment variable](http://www.linfo.org/path_env_var.html)
 so that it contains this path and then, from the root of the project, run `make docs`
 


### PR DESCRIPTION
There are commands to find a package like pip show -f Sphinx, but then
it shows the location of the package and all the files, and you have to
figure out the correct directory from that and the path of the binaries,
which is ../../../bin . Not very handy.