### PR TITLE
Add the mongoDB service to the exporter builds

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -227,6 +227,7 @@ exporter:
       versions:
         symfony: ['2.8', '3.1', '3.2']
         doctrine_odm: ['1']
+      services: [mongodb]
       docs_path: docs
     1.x:
       php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
@@ -234,6 +235,7 @@ exporter:
       versions:
         symfony: ['2.3', '2.7', '2.8', '3.1', '3.2']
         doctrine_odm: ['1']
+      services: [mongodb]
       docs_path: docs
 
 formatter-bundle:


### PR DESCRIPTION
It is needed by the ODM build

Proof PR: https://github.com/sonata-project/exporter/pull/161