### PR TITLE
Drop outdated versions for classification media bundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -89,9 +89,9 @@ classification-bundle:
 classification-media-bundle:
   branches:
     master:
-      php: ['5.3', '5.4', '5.5', '5.6', '7.0']
+      php: ['7.1']
       versions:
-        symfony: ['2.3', '2.7', '2.8', '3.0', '3.1']
+        symfony: ['2.8', '3.2', '3.3']
 
 comment-bundle:
   branches:


### PR DESCRIPTION
This is a new bundle so we don't need any support for older symfony or PHP versions.
