### PR TITLE
Disable/Enable xDebug on PHP 5.3 to avoid breaking travis with slow builds

### DIFF
--- a/project/.travis/before_install_test.sh.twig
+++ b/project/.travis/before_install_test.sh.twig
@@ -6,6 +6,15 @@ if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then
     TRAVIS_INI_FILE="$PHP_INI_DIR/travis.ini"
     echo "memory_limit=3072M" >> "$TRAVIS_INI_FILE"
 
+    {% if '5.3' in php %}
+    if [ "$TRAVIS_PHP_VERSION" '<' '5.4' ]; then
+        XDEBUG_INI_FILE="$PHP_INI_DIR/xdebug.ini"
+        if [ -f  "$XDEBUG_INI_FILE" ]; then
+            mv "$XDEBUG_INI_FILE" /tmp
+        fi
+    fi
+    {% endif %}
+
     {% if 'mongodb' in services %}
     if [ "$TRAVIS_PHP_VERSION" '<' '7.0' ]; then
         echo "extension=mongo.so" >> "$TRAVIS_INI_FILE"

--- a/project/.travis/before_script_test.sh
+++ b/project/.travis/before_script_test.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-set -ev

--- a/project/.travis/before_script_test.sh.twig
+++ b/project/.travis/before_script_test.sh.twig
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ev
+
+{% if '5.3' in php %}
+if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" '<' '5.4' ]; then
+    PHP_INI_DIR="$HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d/"
+    XDEBUG_INI_FILE="/tmp/xdebug.ini"
+    if [ -f  "$XDEBUG_INI_FILE" ]; then
+        mv "$XDEBUG_INI_FILE" "$PHP_INI_DIR"
+    fi
+fi
+{% endif %}


### PR DESCRIPTION
Composer on PHP 5.3 doesn't disable xdebug by itself.

https://getcomposer.org/doc/articles/troubleshooting.md#xdebug-impact-on-composer

This documentation doesn't talk about specific PHP versions, but we can look at travis.

We will see this on the same PR looking at the composer update command:

**This is a PHP 5.3 build**: https://travis-ci.org/sonata-project/SonataAdminBundle/jobs/268565708#L480
**This is a PHP 5.4 build**: https://travis-ci.org/sonata-project/SonataAdminBundle/jobs/268565709#L478

As you can see, from PHP 5.4 it will disable xDebug just fine, so this is only for PHP 5.3 version.

This PR adds a condition that will only be on the branches with 5.3 as one of the tested versions and will only be executed for PHP 5.3 so it is safe for newer versions that can rely on that feature of composer.

This can be removed when none of the branches (newer and older) rely on PHP 5.3

Why is this needed? Some older builds with lower-deps are failing because composer is taking so much time:

https://travis-ci.org/sonata-project/SonataEasyExtendsBundle/jobs/268563720