### PR TITLE
Added tests_path config key

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -219,11 +219,13 @@ ecommerce:
       versions:
         symfony: ['2.8']
       docs_path: docs
+      tests_path: tests
     2.x:
       php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8']
       docs_path: docs
+      tests_path: tests
 
 exporter:
   excluded_files:
@@ -236,6 +238,7 @@ exporter:
         doctrine_odm: ['1']
       services: [mongodb]
       docs_path: docs
+      tests_path: tests
     1.x:
       php: ['5.6', '7.0', '7.1']
       versions:
@@ -243,6 +246,7 @@ exporter:
         doctrine_odm: ['1']
       services: [mongodb]
       docs_path: docs
+      tests_path: tests
 
 formatter-bundle:
   branches:
@@ -381,6 +385,7 @@ timeline-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
       docs_path: docs
+      tests_path: tests
     3.x:
       php: ['5.6', '7.0', '7.1']
       versions:
@@ -389,6 +394,7 @@ timeline-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
       docs_path: docs
+      tests_path: tests
 
 translation-bundle:
   branches:

--- a/project/.gitattributes.twig
+++ b/project/.gitattributes.twig
@@ -1,3 +1,3 @@
 .* export-ignore
 *.md export-ignore
-Tests/* export-ignore
+{{ tests_path }}/* export-ignore

--- a/project/.styleci.yml.twig
+++ b/project/.styleci.yml.twig
@@ -22,7 +22,7 @@ enabled:
 
 finder:
   exclude:
-    - 'Tests/Fixtures'
+    - '{{ tests_path }}/Fixtures'
     # ecommerce special case:
     - 'Resources/skeleton'
     # ignore vendor assets

--- a/src/Config/ProjectsConfiguration.php
+++ b/src/Config/ProjectsConfiguration.php
@@ -60,6 +60,7 @@ class ProjectsConfiguration implements ConfigurationInterface
                                         ->scalarNode('target_php')->defaultNull()->end()
                                         ->append($this->addVersionsNode())
                                         ->scalarNode('docs_path')->defaultValue('Resources/doc')->end()
+                                        ->scalarNode('tests_path')->defaultValue('Tests')->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -514,6 +514,7 @@ final class DispatchCommand extends AbstractNeedApplyCommand
                 '{{ unstable_branch }}',
                 '{{ stable_branch }}',
                 '{{ docs_path }}',
+                '{{ tests_path }}',
                 '{{ website_path }}',
             ], [
                 Inflector::ucwords(str_replace(['-project', '/', '-'], ['', ' ', ' '], $package->getName())),
@@ -524,6 +525,7 @@ final class DispatchCommand extends AbstractNeedApplyCommand
                 $unstableBranch,
                 $stableBranch,
                 $branchConfig['docs_path'],
+                $branchConfig['tests_path'],
                 str_replace([static::PACKAGIST_GROUP.'/', '-bundle'], '', $package->getName()),
             ], $localContent));
         }


### PR DESCRIPTION
The path for all test classes differs between the bundles, either it is `Tests` or `tests`, so we must have a config key for this.