### PR TITLE
Switch from precise to trusty

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -24,7 +24,7 @@ services:
 
 {% endif %}
 sudo: false
-dist: precise
+dist: trusty
 
 cache:
   pip: true
@@ -65,7 +65,6 @@ matrix:
     - php: '{{ php|last }}'
       env: SYMFONY_DEPRECATIONS_HELPER=0
     - php: hhvm
-      dist: trusty
   allow_failures:
     - php: nightly
     - php: hhvm


### PR DESCRIPTION
Since we dropped 5.3, we no longer need to stick with precise.