### PR TITLE
Improve CONTRIBUTING guide.

### DIFF
--- a/project/CONTRIBUTING.md
+++ b/project/CONTRIBUTING.md
@@ -113,9 +113,9 @@ Some rules have to be respected about the test:
   * `@codeCoverageIgnore`
   * `@codeCoverageIgnoreStart`
   * `@codeCoverageIgnoreEnd`
-* All test methods should be prefixed by `test`. Example: `public function testItReturnsNull()`.
-* All test method names must be in camel case format.
+* All test methods must be prefixed by `test`. Example: `public function testItReturnsNull()`.
 * As opposed, the `@test` annotation is prohibited.
+* All test method names must be in camel case format.
 * Most of the time, the test class should have the same name as the targeted class, suffixed by `Test`.
 * The `@expectedException*` annotations are prohibited. Use `PHPUnit_Framework_TestCase::setExpectedException()`.
 


### PR DESCRIPTION
* Tests MUST be prefixed with `test`.
* Moved a sentence which is linked with the previous one.