### PR TITLE
Remove propel admin

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -342,8 +342,6 @@ page-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
 
-propel-admin-bundle: ~
-
 sandbox: ~
 
 seo-bundle:


### PR DESCRIPTION
The tests are failing for a long time and no one is using it, according to https://github.com/sonata-project/SonataPropelAdminBundle/.

So we should remove this project from our config and leave a short note, that the project is abandoned.