### PR TITLE
Add composer flags to every update command, remove quiet flag

### DIFF
--- a/project/.travis/install_test.sh
+++ b/project/.travis/install_test.sh
@@ -19,6 +19,6 @@ chmod u+x "${HOME}/bin/coveralls"
 # To be removed when these issues are resolved:
 # https://github.com/composer/composer/issues/5355
 # https://github.com/composer/composer/issues/5030
-composer update --prefer-dist --no-interaction --prefer-stable --quiet --ignore-platform-reqs
+composer update --prefer-dist --no-interaction --prefer-stable --ignore-platform-reqs ${COMPOSER_FLAGS}
 
 composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}


### PR DESCRIPTION
I made two changes on the first composer update command.

1. Remove quiet flag: now that we are always doing 2 composer update on every build the first one get all the dependencies installes (most of the time with the correct versions), the second one only fixes the problems with --prefer-lowest and --platform-reqs bugs.

2. Add composer_flags to the first command. If this is not present, this build does not pass. Note that it does make sense to install --prefer-lowest both times:

https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/230