### PR TITLE
Do the composer lowest trick only when lowest is requested

### DIFF
--- a/project/.travis/install_test.sh
+++ b/project/.travis/install_test.sh
@@ -19,6 +19,8 @@ chmod u+x "${HOME}/bin/coveralls"
 # To be removed when these issues are resolved:
 # https://github.com/composer/composer/issues/5355
 # https://github.com/composer/composer/issues/5030
-composer update --prefer-dist --no-interaction --prefer-stable --quiet --ignore-platform-reqs
+if [ "${COMPOSER_FLAGS}" = '--prefer-lowest' ]; then
+    composer update --prefer-dist --no-interaction --prefer-stable --quiet --ignore-platform-reqs
+fi
 
 composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}


### PR DESCRIPTION
Introduced in #238, It's currently done on each Travis job of each repo, this is not the wanted behavior.