### PR TITLE
Make PHP version dropping smoother for minor releases

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -7,7 +7,7 @@ admin-bundle:
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
@@ -22,7 +22,7 @@ admin-search-bundle:
         sonata_admin: ['3']
         ruflin_elastica: ['2']
     1.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8']
         sonata_admin: ['3']
@@ -45,7 +45,7 @@ block-bundle:
         # https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/131844587#L222
         #sonata_admin: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
@@ -61,7 +61,7 @@ cache:
       php: ['7.1']
       docs_path: docs
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       docs_path: docs
 
 cache-bundle:
@@ -71,7 +71,7 @@ cache-bundle:
       versions:
         symfony: ['2.8', '3.2', '3.3']
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
 
@@ -83,7 +83,7 @@ classification-bundle:
         symfony: ['2.8', '3.2', '3.3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_admin: ['3']
@@ -103,7 +103,7 @@ comment-bundle:
         symfony: ['2.8']
         sonata_core: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
@@ -115,7 +115,7 @@ core-bundle:
       versions:
         symfony: ['2.8', '3.2', '3.3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
 
@@ -137,7 +137,7 @@ datagrid-bundle:
         symfony: ['2.8', '3.2', '3.3']
       docs_path: docs
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
       docs_path: docs
@@ -151,7 +151,7 @@ doctrine-extensions:
       php: ['7.1']
       docs_path: docs
     1.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       docs_path: docs
 
 doctrine-mongodb-admin-bundle:
@@ -163,7 +163,7 @@ doctrine-mongodb-admin-bundle:
         symfony: ['2.8', '3.2', '3.3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       services: [mongodb]
       versions:
         symfony: ['2.8', '3.2', '3.3']
@@ -178,7 +178,7 @@ doctrine-orm-admin-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
@@ -194,7 +194,7 @@ doctrine-phpcr-admin-bundle:
         sonata_block: ['3']
       docs_path: docs
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_admin: ['3']
@@ -208,7 +208,7 @@ easy-extends-bundle:
       versions:
         symfony: ['2.8', '3.2', '3.3']
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
 
@@ -220,7 +220,7 @@ ecommerce:
         symfony: ['2.8']
       docs_path: docs
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8']
       docs_path: docs
@@ -237,7 +237,7 @@ exporter:
       services: [mongodb]
       docs_path: docs
     1.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         doctrine_odm: ['1']
@@ -253,7 +253,7 @@ formatter-bundle:
         sonata_core: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
@@ -268,7 +268,7 @@ google-authenticator:
       php: ['7.1']
       docs_path: docs
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       docs_path: docs
 
 intl-bundle:
@@ -279,7 +279,7 @@ intl-bundle:
         symfony: ['2.8', '3.2', '3.3']
         sonata_user: ['3']
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_user: ['3']
@@ -295,7 +295,7 @@ media-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       services: [mongodb]
       versions:
         symfony: ['2.8', '3.2', '3.3']
@@ -313,7 +313,7 @@ news-bundle:
         sonata_admin: ['3']
         sonata_user: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
@@ -328,7 +328,7 @@ notification-bundle:
         symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
@@ -343,7 +343,7 @@ page-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8']
         sonata_core: ['3']
@@ -364,7 +364,7 @@ seo-bundle:
         sonata_admin: ['3']
       docs_path: docs
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_block: ['3']
@@ -382,7 +382,7 @@ timeline-bundle:
         sonata_block: ['3']
       docs_path: docs
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
@@ -399,7 +399,7 @@ translation-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
@@ -415,7 +415,7 @@ user-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1']
+      php: ['5.6', '7.0', '7.1']
       versions:
         symfony: ['2.8']
         fos_user: ['1.3']

--- a/project/CONTRIBUTING.md
+++ b/project/CONTRIBUTING.md
@@ -321,7 +321,8 @@ If you want to change some dependencies, here are the rules:
 - Don't change the highest supported version to a lower one.
 - Lower version dropping is accepted as a Backward Compatible change according to [semver][semver_dependencies_update],
 but some extra rules must be respected here:
-  - PHP versions that are under the [green zone][php_supported_versions] (actively maintained) **MUST NO** be dropped, even on master.
+  - PHP versions that are under the [orange zone][php_supported_versions] (Security Support) **MUST NOT** be dropped on the stable branch.
+  - PHP versions that are under the [green zone][php_supported_versions] (Active Support) **MUST NOT** be dropped on the master branch.
   - If it's a Symfony package, at least the last LTS version **MUST** be supported, even on master.
   - Generally, don't drop dependency version it it doesn't have a big impact on the code.
 


### PR DESCRIPTION
Closes #315 
Closes #316 

Somes notes:

1. Master branch will keep 7.1 as minimum requirement because PHP 7.0 will end in one month: https://github.com/sonata-project/dev-kit/issues/316#issuecomment-339441009
This is an exceptional case, we should not drop PHP version from green zone in the future
2. This rule change does apply for PHP only because it's a system wide dependency. This changea nothing for the Symfony dependency. It's still a composer dependency as another package. So only **the last LTS** will be supported on minor release.
3. Of course, in addition to `2` and the contributing guide, Symfony 2.8 support will be kept if it's possible to do that without too much difficulty and code complexity.