### PR TITLE
Use the weak vendors mode

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -34,7 +34,7 @@ cache:
 env:
   global:
     - PATH="$HOME/.local/bin:$PATH"
-    - SYMFONY_DEPRECATIONS_HELPER=weak
+    - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/{{ repository_name }}.git
     - XMLLINT_INDENT="    "


### PR DESCRIPTION
This is stricter than the weak mode, but still will not make the build
fail if the deprecation comes from a vendor. However, if a deprecation
is contributed and we call our own deprecated code, or do so in a test
without adding said test to the "legacy" phpunit group, the build will
fail.