### PR TITLE
Revert "Use the weak vendors mode"

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -34,7 +34,7 @@ cache:
 env:
   global:
     - PATH="$HOME/.local/bin:$PATH"
-    - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
+    - SYMFONY_DEPRECATIONS_HELPER=weak
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/{{ repository_name }}.git
     - XMLLINT_INDENT="    "


### PR DESCRIPTION
This mode is risky and will fail some build, because there is a bug that will be fixed in symfony 3.4.

Refs: https://github.com/sonata-project/SonataPageBundle/pull/895