### PR TITLE
Fix mongo db installation on PHP >= 7.0

### DIFF
--- a/project/.travis/before_install_test.sh.twig
+++ b/project/.travis/before_install_test.sh.twig
@@ -21,7 +21,7 @@ else
     echo "extension=mongodb.so" >> "$TRAVIS_INI_FILE"
 
     # Backwards compatibility with old mongo extension
-    composer require "alcaeus/mongo-php-adapter" --no-update
+    composer require "alcaeus/mongo-php-adapter" --ignore-platform-reqs
 fi
 {% endif %}
 


### PR DESCRIPTION
This fixes all issues with mongodb on PHP >= 7.0.

@greg0ire found a solution on exporter https://github.com/sonata-project/exporter/pull/193 that consist on installing the `mongodb-adapter` with the `--ignore-platform-reqs` flag, which is the recommended way to install it: https://github.com/alcaeus/mongo-php-adapter#installation

I applied his solution here.

Proof PR:

https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/242
https://github.com/sonata-project/SonataMediaBundle/pull/1319

