### PR TITLE
Revert cache and googleauthenticator versions

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -63,7 +63,7 @@ cache:
       php: ['7.1']
       docs_path: docs
     2.x:
-      php: ['5.6', '7.0', '7.1']
+      php: ['7.1']
       docs_path: docs
 
 cache-bundle:
@@ -284,7 +284,7 @@ google-authenticator:
       php: ['7.1']
       docs_path: docs
     2.x:
-      php: ['5.6', '7.0', '7.1']
+      php: ['7.1']
       docs_path: docs
 
 intl-bundle:


### PR DESCRIPTION
There are so many signature changes that we can't revert,
because of that we need to mantain 7.1 as a minimum requirement