### PR TITLE
Add travis wait

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -80,7 +80,7 @@ before_install:
   - if [ -x .travis/before_install_${TARGET}.sh ]; then .travis/before_install_${TARGET}.sh; fi;
 
 install:
-  - if [ -x .travis/install_${TARGET}.sh ]; then .travis/install_${TARGET}.sh; fi;
+  - if [ -x .travis/install_${TARGET}.sh ]; then travis_wait 30 .travis/install_${TARGET}.sh; fi;
 
 before_script:
   - if [ -x .travis/before_script_${TARGET}.sh ]; then .travis/before_script_${TARGET}.sh; fi;


### PR DESCRIPTION
What do you think on having travis_wait for the `install_{TARGET}`?

We need atleast 30 minutes as I tested here: https://github.com/sonata-project/ecommerce/pull/480

Bad things about having this one:

- We don't have any logs of that bash script until it is finished executing, because of the travis_wait.
- most of the bundles don't need it, there are just a few ones and only on the `--prefer-lowest` build