### PR TITLE
Test Symfony3 on bundles that are already using it

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -102,14 +102,14 @@ comment-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
       docs_path: Resources/doc
       tests_path: Tests
     3.x:
       php: ['5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.8']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
       docs_path: Resources/doc
       tests_path: Tests
@@ -306,14 +306,14 @@ news-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_user: ['3']
     3.x:
       php: ['5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.8']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_user: ['3']
@@ -336,14 +336,14 @@ page-bundle:
     master:
       php: ['7.1']
       versions:
-        symfony: ['2.8']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
       php: ['5.6', '7.0', '7.1']
       versions:
-        symfony: ['2.8']
+        symfony: ['2.8', '3.2', '3.3']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']


### PR DESCRIPTION
SonataCommentBundle, SonataNewsBundle, SonataPageBundle
are using SF3 on composer.json but it is not on travis builds

Proof on composer.json:

https://github.com/sonata-project/SonataPageBundle/blob/3.x/composer.json
https://github.com/sonata-project/SonataCommentBundle/blob/3.x/composer.json
https://github.com/sonata-project/SonataNewsBundle/blob/3.x/composer.json