### PR TITLE
Add .x-dev to package specific dev-master builds

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -59,7 +59,7 @@ matrix:
 {% endfor %}
 {% if package_versions|length > 0 %}
     - php: '{{ target_php|default(php|last) }}'
-      env: {{ package_name|upper }}='dev-master as {{ package_versions|last }}'
+      env: {{ package_name|upper }}='dev-master as {{ package_versions|last }}.x-dev'
 {% endif %}
 {% endfor %}
     - php: '{{ php|last }}'
@@ -69,7 +69,7 @@ matrix:
     - env: SYMFONY_DEPRECATIONS_HELPER=0
 {% for package_name,package_versions in versions %}
 {% if package_versions|length > 0 %}
-    - env: {{ package_name|upper }}='dev-master as {{ package_versions|last }}'
+    - env: {{ package_name|upper }}='dev-master as {{ package_versions|last }}.x-dev'
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
With this we can get more greens on the allowed failures builds. Why?

Because on some cases, those builds require a version upper than just `3` of Corebundle for example: 
https://travis-ci.org/sonata-project/SonataTranslationBundle/builds/303615904

With this change we are aliasing with the `3.x-dev` version which is the latest and cannot fail due to a requirement on composer.json

Proof:
https://travis-ci.org/sonata-project/SonataTranslationBundle/builds/306030700
https://github.com/sonata-project/SonataTranslationBundle/pull/205

*Note*: Do not look at `--prefer-lowest` build, it is unrelated.