### PR TITLE
Install xmllint manually

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -26,6 +26,11 @@ services:
 sudo: false
 dist: trusty
 
+addons:
+  apt:
+    packages:
+      - libxml2-utils
+
 cache:
   pip: true
   directories:

--- a/project/Makefile
+++ b/project/Makefile
@@ -11,8 +11,8 @@ lint:
 	composer validate
 	find . -name '*.yml' -not -path './vendor/*' -not -path './Resources/public/vendor/*' | xargs yaml-lint
 	find . \( -name '*.xml' -or -name '*.xliff' \) \
-		-not -path './vendor/*' -not -path './Resources/public/vendor/*' -type f \
-		-exec xmllint --encode UTF-8 --output '{}' --format '{}' \;
+		-not -path './vendor/*' -not -path './Resources/public/vendor/*' \
+		| xargs -I'{}' xmllint --encode UTF-8 --output '{}' --format '{}'
 	php-cs-fixer fix --verbose
 	git diff --exit-code
 


### PR DESCRIPTION
Closes #359 

Xmllint is not installed by default since we use trusty: https://github.com/xwp/wp-dev-lib/issues/247

Proof that it does not work: just look at this lint build, there are a lot of lines of xmllint not found https://travis-ci.org/sonata-project/SonataAdminBundle/jobs/311420072