### PR TITLE
Remove php70 rule from general rules

### DIFF
--- a/project/.php_cs.dist
+++ b/project/.php_cs.dist
@@ -33,7 +33,6 @@ $rules = [
     'ordered_class_elements' => true,
     'ordered_imports' => true,
     'phpdoc_order' => true,
-    'ternary_to_null_coalescing' => true,
     // To be tested before insertion:
 //    'strict_comparison' => true,
 //    'strict_param' => true,
@@ -49,12 +48,14 @@ if (\PHP_VERSION_ID >= 50600) {
 }
 if (\PHP_VERSION_ID >= 70000) {
     $rules = array_merge($rules, [
+        '@PHP70Migration' => true,
         '@PHP70Migration:risky' => true,
         '@PHPUnit60Migration:risky' => true,
     ]);
 }
 if (\PHP_VERSION_ID >= 70100) {
     $rules = array_merge($rules, [
+        '@PHP71Migration' => true,
         '@PHP71Migration:risky' => true,
         'compact_nullable_typehint' => true,
     ]);

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -30,10 +30,10 @@ use Symfony\Component\Yaml\Yaml;
  */
 abstract class AbstractCommand extends Command
 {
-    const GITHUB_GROUP = 'sonata-project';
-    const GITHUB_USER = 'SonataCI';
-    const GITHUB_EMAIL = 'thomas+ci@sonata-project.org';
-    const PACKAGIST_GROUP = 'sonata-project';
+    public const GITHUB_GROUP = 'sonata-project';
+    public const GITHUB_USER = 'SonataCI';
+    public const GITHUB_EMAIL = 'thomas+ci@sonata-project.org';
+    public const PACKAGIST_GROUP = 'sonata-project';
 
     /**
      * @var SymfonyStyle

--- a/src/Console/Command/DispatchCommand.php
+++ b/src/Console/Command/DispatchCommand.php
@@ -28,7 +28,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class DispatchCommand extends AbstractNeedApplyCommand
 {
-    const LABEL_NOTHING_CHANGED = 'Nothing to be changed.';
+    public const LABEL_NOTHING_CHANGED = 'Nothing to be changed.';
 
     /**
      * @var GitWrapper


### PR DESCRIPTION
This rule should be part of `PHP70Migration` since it is only allowed to use it under php 7.0 as minimum