### PR TITLE
Fix install for mongodb

### DIFF
--- a/project/.travis/before_install_test.sh.twig
+++ b/project/.travis/before_install_test.sh.twig
@@ -20,8 +20,10 @@ if [ "$TRAVIS_PHP_VERSION" '<' '7.0' ]; then
 else
     echo "extension=mongodb.so" >> "$TRAVIS_INI_FILE"
 
+    # https://github.com/composer/composer/issues/5030
+    composer config "platform.ext-mongo" "1.6.16"
     # Backwards compatibility with old mongo extension
-    composer require "alcaeus/mongo-php-adapter" --ignore-platform-reqs
+    composer require "alcaeus/mongo-php-adapter"
 fi
 {% endif %}
 

--- a/project/.travis/install_test.sh
+++ b/project/.travis/install_test.sh
@@ -13,9 +13,8 @@ chmod u+x "${HOME}/bin/coveralls"
 
 # To be removed when these issues are resolved:
 # https://github.com/composer/composer/issues/5355
-# https://github.com/composer/composer/issues/5030
 if [ "${COMPOSER_FLAGS}" = '--prefer-lowest' ]; then
-    composer update --prefer-dist --no-interaction --prefer-stable --quiet --ignore-platform-reqs
+    composer update --prefer-dist --no-interaction --prefer-stable --quiet
 fi
 
 composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}


### PR DESCRIPTION
This finally fixes the issue in a cleaner way. We don't need anymore the `--ignore-platform-reqs`, which is good.

And we only modify things for the builds that need mongodb.

Proof: https://travis-ci.org/sonata-project/SonataDoctrineMongoDBAdminBundle/jobs/312910083

And the idea comes from here:

https://github.com/alcaeus/mongo-php-adapter/pull/207

Thanks @alcaeus