### PR TITLE
Add Symfony 3.2, 3.3 and 3.4 for ecommerce

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -209,7 +209,7 @@ ecommerce:
     master:
       php: ['7.1', '7.2']
       versions:
-        symfony: ['2.8']
+        symfony: ['2.8', '3.2', '3.3', '3.4']
     2.x:
       php: ['5.6', '7.0', '7.1', '7.2']
       versions:


### PR DESCRIPTION
After sonata-project/ecommerce#485 we can build it with sf 3 on master