### PR TITLE
FlintCI integration

### DIFF
--- a/.flintci.yml
+++ b/.flintci.yml
@@ -1,0 +1,1 @@
+project/.flintci.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,1 @@
+project/.yamllint

--- a/project/.editorconfig
+++ b/project/.editorconfig
@@ -13,7 +13,7 @@ indent_size = 4
 [*.{js,json,scss,css}]
 indent_size = 2
 
-[.travis.yml]
+[.{travis.yml,flintci.yml}]
 indent_size = 2
 
 [composer.json]

--- a/project/.flintci.yml
+++ b/project/.flintci.yml
@@ -1,0 +1,3 @@
+services:
+  phpcsfixer: true
+  yamllint: true

--- a/project/.yamllint
+++ b/project/.yamllint
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  document-start: disable
+  line-length:
+    max: 120
+    level: warning


### PR DESCRIPTION
Proof PR: https://github.com/sonata-project/SonataAdminBundle/pull/4866

Because this deploy is also a way to test FlintCI, the build status will not be required yet and the lint commands of TravisCI are still set up.

A reminder was created here: https://github.com/sonata-project/dev-kit/issues/376

Please also note I'll deploy dev-kit just after the merge to not having the current build stuck because of the activations on FlintCI.