### PR TITLE
[RFC] use build stages on travis

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -42,17 +42,24 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=weak
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/{{ repository_name }}.git
+stages:
+  - lint
+  - docs
+  - test
 
-matrix:
+jobs:
   fast_finish: true
   include:
 {% if docs_target %}
-    - php: '{{ php|last }}'
+    - stage: docs
+      php: '{{ php|last }}'
       env: TARGET=docs
 {% endif %}
-    - php: '{{ php|last }}'
+    - stage: lint
+      php: '{{ php|last }}'
       env: TARGET=lint
-    - php: '{{ php|first }}'
+    - stage: test
+      php: '{{ php|first }}'
       env: COMPOSER_FLAGS="--prefer-lowest"
 {% for package_name,package_versions in versions %}
 {% for version in package_versions %}


### PR DESCRIPTION
refs https://docs.travis-ci.com/user/build-stages/#How-to-define-Build-Stages%3F

Proof PR: https://github.com/sonata-project/SonataNotificationBundle/pull/308

https://travis-ci.org/sonata-project/SonataNotificationBundle/builds/332209819?utm_source=github_status&utm_medium=notification

![ohne titel](https://user-images.githubusercontent.com/995707/35269153-8867230a-002b-11e8-8f1f-918463dfe78a.png)


allowed failures are grouped under the stage, but an info note is shown IF a build failed which was allowed to fail!