### PR TITLE
Run lowest versions job together with lowest version of Symfony

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -53,7 +53,7 @@ matrix:
     - php: '{{ php|last }}'
       env: TARGET=lint
     - php: '{{ php|first }}'
-      env: COMPOSER_FLAGS="--prefer-lowest"
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY={{ versions.symfony|first }}.*
 {% for package_name,package_versions in versions %}
 {% for version in package_versions %}
     - php: '{{ target_php|default(php|last) }}'


### PR DESCRIPTION
When i increased dependency version in my PR https://github.com/sonata-project/SonataFormatterBundle/pull/315 travis failed every time, i pushed to github. I tried to speed up composer to avoid failures. Here are my tries:

| Status | block-bundle | EnvVar | Job | Ran for |
| --- | --- | --- | --- | --- |
| Failure | ^3.11 | | [#939.7](https://travis-ci.org/sonata-project/SonataFormatterBundle/jobs/332731689) | 12 min 41 sec |
| Success | ^3.2 | | [#940.7](https://travis-ci.org/sonata-project/SonataFormatterBundle/jobs/332830146) | 11 min 48 sec |
| Success | ^3.11 | SYMFONY=2.8.0 | [#941.7](https://travis-ci.org/sonata-project/SonataFormatterBundle/jobs/332845215) | **4 min 39 sec** |
| Success | ^3.11 | SYMFONY_LTS=2 | [#942.7](https://travis-ci.org/sonata-project/SonataFormatterBundle/jobs/332945647) | 12 min 37 sec |
| Success | ^3.11 | SYMFONY=2.8.* | [#943.7](https://travis-ci.org/sonata-project/SonataFormatterBundle/jobs/333164319) | **4 min 53 sec** |

So, my suggestion is to pass `SYMFONY` env variable with lowest Symfony version to a job with `COMPOSER_FLAGS="--prefer-lowest"` variable:

```yaml
matrix:
  fast_finish: true
  include:
    # ...
    - php: '5.6'
      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY=2.8.*
    # ...
```