### PR TITLE
Add xml lint to flintCI

### DIFF
--- a/project/.flintci.yml
+++ b/project/.flintci.yml
@@ -2,3 +2,4 @@ services:
   composernormalize: true
   phpcsfixer: true
   yamllint: true
+  xmllint: true


### PR DESCRIPTION
With this one, flintCI becomes the same as we do with the travis lint build. So after this one, we could remove that build and make flintCI required on all projects.

@Soullivaneuh is the xml lint ready to use on our repos or is there something wrong with it?