### PR TITLE
Use -i and -e options of yaml-lint included in 0.0.10

### DIFF
--- a/project/Makefile
+++ b/project/Makefile
@@ -14,7 +14,7 @@ lint-composer:
 .PHONY: lint-composer
 
 lint-yaml:
-	find . -name '*.yml' -not -path './vendor/*' -not -path './src/Resources/public/vendor/*' | xargs yaml-lint
+	yaml-lint --ignore-non-yaml-files --quiet --exclude vendor .
 
 .PHONY: lint-yaml
 


### PR DESCRIPTION
With the release of `yaml-lint` `0.0.10` it is now possible to exclude directories (in there, all the directories named `vendor` will be excluded and the non-yaml files will be ignored. The `-q` has been added to suppress non-useful output.

Closes: #186 