### PR TITLE
Automate some of the release process

### DIFF
--- a/latest-prs
+++ b/latest-prs
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+function stable_branch()
+{
+	git branch --format='%(refname:lstrip=2)'|grep '^[0-9].x$'|sort|tail --lines=1
+}
+
+function latest_tag_date()
+{
+	git --no-pager show --format=%aI --no-patch "$(git describe --abbrev=0 --tags)"|tail --lines 1
+}
+
+function urlencode()
+{
+	read -r toEncode
+	php --run "echo urlencode('$toEncode');"
+}
+
+function current_branch()
+{
+	git rev-parse --abbrev-ref HEAD
+}
+
+function repo_path()
+{
+	git remote --verbose \
+		| grep sonata \
+		| grep 'git@' \
+		| head --lines=1 \
+		| cut --delimiter=':' --fields=2 \
+		| cut --delimiter='.' --fields=1
+}
+git checkout "$(stable_branch)"
+git pull --all --prune
+xdg-open "https://github.com/$(repo_path)/pulls?q=base:$(current_branch)+merged:>$(latest_tag_date|urlencode)"

--- a/project/CONTRIBUTING.md
+++ b/project/CONTRIBUTING.md
@@ -562,6 +562,8 @@ After that, go on the pull requests page of the repo and replace the default fil
 base:3.x merged:>2018-04-20T09:47:48Z
 ```
 
+All the previous steps are automated up in [this shell script](https://github.com/sonata-project/dev-kit/latest-prs).
+
  - `base`: The base branch where the PR are merged.
  It MUST be the current stable branch, or the legacy branch where you want to make a release.
  - `merged`: All the pull request merged **after** the given datetime.


### PR DESCRIPTION
This should make the process less boring/error-prone.
Can someone on Mac make it work for this OS and make a PR on this PR? There are probably some long options or some binaries not available `xdg-open` vs `open`?