### PR TITLE
Join the Hacktoberfest (again again)

### DIFF
--- a/config/dev-kit.yml
+++ b/config/dev-kit.yml
@@ -39,6 +39,8 @@ labels:
     color: '006b75'
   - name: 'Needs: Upgrade note'
     color: '006b75'
+  - name: 'hacktoberfest'
+    color: 'b0581d'
 
 packages:
   symfony: symfony/symfony


### PR DESCRIPTION
Support and celebrate open source. Earn a limited edition T-shirt.
https://blog.github.com/2018-09-24-hacktoberfest-is-back-and-celebrating-its-fifth-year/

We could join this event again (#210, #290) to support the open source community and get some more contributions.