### PR TITLE
Bump all php versions smaler then 7.1 in phpcr admin bundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -362,7 +362,7 @@ seo-bundle:
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2']
+      php: ['7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_block: ['3']


### PR DESCRIPTION
As said in https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/521 i would have to drop some php version in Adminbundle