### PR TITLE
Fixed seo-bundle setup

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -362,7 +362,7 @@ seo-bundle:
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['7.1', '7.2']
+      php: ['5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_block: ['3']


### PR DESCRIPTION
We can't drop a major php version on a stable branch.

Reverts https://github.com/sonata-project/dev-kit/pull/427
Fixes https://github.com/sonata-project/SonataSeoBundle/pull/285 
Fixes https://github.com/sonata-project/SonataSeoBundle/pull/284
cc @ElectricMaxxx 