### PR TITLE
Fix 7.3 apocalypse

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -18,7 +18,7 @@ admin-bundle:
 admin-search-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -1,14 +1,14 @@
 admin-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_block: ['3']
         symfony_maker: ['1.7']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -18,13 +18,13 @@ admin-bundle:
 admin-search-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
         ruflin_elastica: ['2']
     1.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_admin: ['3']
@@ -33,21 +33,21 @@ admin-search-bundle:
 article-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
 
 block-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         # https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/131844587#L222
         #sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -60,30 +60,30 @@ cache:
   docs_target: false
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
 
 cache-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
 
 classification-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_admin: ['3']
@@ -91,19 +91,19 @@ classification-bundle:
 classification-media-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
 
 comment-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -111,18 +111,18 @@ comment-bundle:
 core-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
 
 dashboard-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -132,11 +132,11 @@ dashboard-bundle:
 datagrid-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
 
@@ -146,20 +146,20 @@ doctrine-extensions:
   docs_target: false
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
     1.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
 
 doctrine-mongodb-admin-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       services: [mongodb]
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       services: [mongodb]
       versions:
         symfony: ['2.8', '3.3', '3.4']
@@ -168,13 +168,13 @@ doctrine-mongodb-admin-bundle:
 doctrine-orm-admin-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -185,13 +185,13 @@ doctrine-phpcr-admin-bundle:
     - phpunit.xml.dist
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
         sonata_block: ['3']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_admin: ['3']
@@ -200,22 +200,22 @@ doctrine-phpcr-admin-bundle:
 easy-extends-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
 
 ecommerce:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8']
 
@@ -224,13 +224,13 @@ exporter:
     - README.md
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         doctrine_odm: ['1']
       services: [mongodb]
     1.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         doctrine_odm: ['1']
@@ -239,13 +239,13 @@ exporter:
 formatter-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.3', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_block: ['3']
     4.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -254,7 +254,7 @@ formatter-bundle:
 form-extensions:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
 
 google-authenticator:
   excluded_files:
@@ -262,19 +262,19 @@ google-authenticator:
   docs_target: false
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
 
 intl-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_user: ['3']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_user: ['3']
@@ -282,7 +282,7 @@ intl-bundle:
 media-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       services: [mongodb]
       versions:
         symfony: ['3.4']
@@ -290,7 +290,7 @@ media-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       services: [mongodb]
       versions:
         symfony: ['2.8', '3.3', '3.4']
@@ -301,14 +301,14 @@ media-bundle:
 news-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_user: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -318,12 +318,12 @@ news-bundle:
 notification-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -331,14 +331,14 @@ notification-bundle:
 page-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -352,13 +352,13 @@ sandbox:
 seo-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_block: ['3']
@@ -367,14 +367,14 @@ seo-bundle:
 timeline-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -384,13 +384,13 @@ timeline-bundle:
 translation-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.3', '5.6', '7.0', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         sonata_core: ['3']
@@ -399,19 +399,19 @@ translation-bundle:
 twig-extensions:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
 
 user-bundle:
   branches:
     master:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['3.4']
         fos_user: ['2']
         sonata_core: ['3']
         sonata_admin: ['3']
     4.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.3', '7.1', '7.2']
       versions:
         symfony: ['2.8', '3.3', '3.4']
         fos_user: ['2']


### PR DESCRIPTION
The last version is used as a default version for most jobs, and we do
not want to use 7.3 for this, since it is not stable yet. This should
fix the issue, and we can put 7.3 last when it is finally stable.