### PR TITLE
Use a better strategy to pick the phpunit version

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -42,6 +42,7 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/{{ repository_name }}.git
+    - PHPUNIT_VERSION={{ '5.6' in php ? '5.7': '7' }}
 
 matrix:
   fast_finish: true

--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -42,7 +42,7 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/{{ repository_name }}.git
-    - PHPUNIT_VERSION={{ '5.6' in php ? '5.7': '7' }}
+    - PHPUNIT_VERSION={{ '5.6' in php ? '5.7' : '7' }}
 
 matrix:
   fast_finish: true

--- a/project/.travis/install_test.sh
+++ b/project/.travis/install_test.sh
@@ -3,12 +3,6 @@ set -ev
 
 mkdir --parents "${HOME}/bin"
 
-# PHPUnit install
-if [ "${TRAVIS_BRANCH}" = 'master' ]; then
-    PHPUNIT_VERSION=7
-else
-    PHPUNIT_VERSION=5.7
-fi
 wget "https://phar.phpunit.de/phpunit-${PHPUNIT_VERSION}.phar" --output-document="${HOME}/bin/phpunit"
 chmod u+x "${HOME}/bin/phpunit"
 


### PR DESCRIPTION
Right now, repositories like the SonataArticleBundle one use phpunit 5.7
on their stable branch even though they only support php 7 and could use
phpunit 7. This moves the condition in the .travis.yml, meaning it will
be computed by Twig. We do not need bash conditions since we have one
.travis.yml per branch.