### PR TITLE
Put subject first

### DIFF
--- a/project/.github/PULL_REQUEST_TEMPLATE.md
+++ b/project/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
 <!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
+## Subject
+
+<!-- Describe your Pull Request content here -->
 
 <!--
     Show us you choose the right branch.
@@ -56,7 +59,3 @@ Closes #{put_issue_number_here}
     - [ ] Update the documentation
     - [ ] Add an upgrade note
 -->
-
-## Subject
-
-<!-- Describe your Pull Request content here -->


### PR DESCRIPTION
We can see a preview of the pull request in our Slack channel, but we
care most about the subject, not the rest. We can still check for the
other things first when reviewing the pull request.

# Before

![before](https://user-images.githubusercontent.com/657779/49339531-b4b00680-f633-11e8-94af-0f1c542cff3d.png)

# After

![after](https://user-images.githubusercontent.com/657779/49339534-c1ccf580-f633-11e8-97b9-17f1972df6ef.png)
