### PR TITLE
Use proper indention

### DIFF
--- a/project/tests/bootstrap.php.twig
+++ b/project/tests/bootstrap.php.twig
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * This file is part of the Sonata Project package.
  *
  * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
-*
-* For the full copyright and license information, please view the LICENSE
-* file that was distributed with this source code.
-*/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 /*
  * fix encoding issue while running text on different host with different locale configuration


### PR DESCRIPTION
This caused many builds to fail because the stars are not aligned (the
one in the comments :P)