### PR TITLE
ignore requirements.txt. file

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -257,6 +257,8 @@ formatter-bundle:
 
 form-extensions:
   docs_target: false
+  excluded_files:
+    - docs/requirements.txt
   branches:
     master:
       php: ['7.2']
@@ -403,6 +405,8 @@ translation-bundle:
 
 twig-extensions:
   docs_target: false
+  excluded_files:
+    - docs/requirements.txt
   branches:
     master:
       php: ['7.2']


### PR DESCRIPTION
Since https://github.com/sonata-project/dev-kit/pull/443 we will manage the configuration file via dev-kit.

This will create the file, if we have docs or not. We don't need this file for repositories containing no docs.