### PR TITLE
use concrete phpunit version as 5.7 is not available anymore

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -42,7 +42,7 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/{{ repository_name }}.git
-    - PHPUNIT_VERSION={{ '5.6' in php ? '5.7' : '7' }}
+    - PHPUNIT_VERSION={{ '5.6' in php ? '5.7.26' : '7' }}
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Currently we do have several failing builds as fetching phpunit 5.7 ends in an 404. This PR fixes those builds by setting a concrete version for 5.7.x