### PR TITLE
remove PHP-CS-Fixer from lint target

### DIFF
--- a/project/.travis/install_lint.sh
+++ b/project/.travis/install_lint.sh
@@ -3,9 +3,6 @@ set -ev
 
 mkdir --parents "${HOME}/bin"
 
-wget "http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar" --output-document="${HOME}/bin/php-cs-fixer"
-chmod u+x "${HOME}/bin/php-cs-fixer"
-
 composer global require sllh/composer-lint:@stable --prefer-dist --no-interaction
 
 gem install yaml-lint


### PR DESCRIPTION
we are using FlintCI and currently PHP-CS-Fixer does not support PHP 7.3

https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3697