### PR TITLE
Stop testing unsupported versions of PHP

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -8,7 +8,7 @@ admin-bundle:
         sonata_block: ['3']
         symfony_maker: ['1.7']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -24,7 +24,7 @@ admin-search-bundle:
         sonata_admin: ['3']
         ruflin_elastica: ['2']
     1.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
@@ -51,7 +51,7 @@ block-bundle:
         # https://travis-ci.org/sonata-project/SonataBlockBundle/jobs/131844587#L222
         #sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -87,7 +87,7 @@ classification-bundle:
         symfony: ['3.4']
         sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
@@ -107,7 +107,7 @@ comment-bundle:
         symfony: ['3.4']
         sonata_core: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -119,7 +119,7 @@ core-bundle:
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
 
@@ -140,7 +140,7 @@ datagrid-bundle:
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
 
@@ -152,7 +152,7 @@ doctrine-extensions:
     master:
       php: ['7.2', '7.3']
     1.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
 
 doctrine-mongodb-admin-bundle:
   branches:
@@ -163,7 +163,7 @@ doctrine-mongodb-admin-bundle:
         symfony: ['3.4']
         sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       services: [mongodb]
       versions:
         symfony: ['3.4']
@@ -178,7 +178,7 @@ doctrine-orm-admin-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -195,7 +195,7 @@ doctrine-phpcr-admin-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
@@ -208,7 +208,7 @@ easy-extends-bundle:
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
 
@@ -219,7 +219,7 @@ ecommerce:
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['2.8']
 
@@ -281,7 +281,7 @@ intl-bundle:
         symfony: ['3.4']
         sonata_user: ['3']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_user: ['3']
@@ -297,7 +297,7 @@ media-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       services: [mongodb]
       versions:
         symfony: ['3.4']
@@ -315,7 +315,7 @@ news-bundle:
         sonata_admin: ['3']
         sonata_user: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -330,7 +330,7 @@ notification-bundle:
         symfony: ['3.4']
         sonata_core: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -345,7 +345,7 @@ page-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -365,7 +365,7 @@ seo-bundle:
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_block: ['3']
@@ -381,7 +381,7 @@ timeline-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -397,7 +397,7 @@ translation-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']


### PR DESCRIPTION
Regardless of whether we continue to support php 5.6 or php 7.0, if a
new bug is discovered, and if affects these versions of php, and if
affects us, we will be stuck and will not be able to move forward. So
let us just stop testing with these versions and decide whether we stop
supporting them and when separately.

See https://secure.php.net/supported-versions.php