### PR TITLE
Handle void return manually

### DIFF
--- a/project/.php_cs.dist.twig
+++ b/project/.php_cs.dist.twig
@@ -46,6 +46,7 @@ $rules = [
     '@PHP71Migration:risky' => true,
     'compact_nullable_typehint' => true,
 {% endif %}
+    'void_return' => null,
     // To be tested before insertion:
 //    'strict_comparison' => true,
 //    'strict_param' => true,


### PR DESCRIPTION
This is an emergency measure, maybe we will be able to re-enable it in
the future, or enable it conditionally.

I noticed things could be simplified in that file due to dropping php 5, but did not because I don't want this one to be blocked.