### PR TITLE
[WIP] enable additional rules for PHP-CS-Fixer

### DIFF
--- a/project/.php_cs.dist.twig
+++ b/project/.php_cs.dist.twig
@@ -47,10 +47,9 @@ $rules = [
     'compact_nullable_typehint' => true,
 {% endif %}
     'void_return' => null,
-    // To be tested before insertion:
-//    'strict_comparison' => true,
-//    'strict_param' => true,
-//    'php_unit_strict' => true,
+    'strict_comparison' => true,
+    'strict_param' => true,
+    'php_unit_strict' => true,
 ];
 
 


### PR DESCRIPTION
## Proof PRs

### SonataAdminBundle
- [ ] ❌  `phpunit_strict_rule` https://github.com/sonata-project/SonataAdminBundle/pull/5444
- [x] ✅ `strict_param` https://github.com/sonata-project/SonataAdminBundle/pull/5442 
- [x] ✅ `strict_comparison` https://github.com/sonata-project/SonataAdminBundle/pull/5440 

### SonataTranslationBundle
- [ ] ❌ `phpunit_strict_rule`, `strict_param` & `strict_comparison` https://github.com/sonata-project/SonataTranslationBundle/pull/277