### PR TITLE
Conditonally dump and prepend xdebug filter

### DIFF
--- a/project/Makefile
+++ b/project/Makefile
@@ -54,11 +54,19 @@ cs-fix-xml:
 build:
 	mkdir $@
 
+HAS_XDEBUG=$(shell php --modules|grep --quiet xdebug;echo $$?)
+
 build/xdebug-filter.php: phpunit.xml.dist build
-	phpunit  --dump-xdebug-filter $@
+ifeq ($(HAS_XDEBUG), 0)
+	phpunit --dump-xdebug-filter $@
+endif
 
 test: build/xdebug-filter.php
+ifeq ($(HAS_XDEBUG), 0)
 	phpunit --prepend build/xdebug-filter.php -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
+else
+	phpunit -c phpunit.xml.dist
+endif
 .PHONY: test
 
 docs:


### PR DESCRIPTION
Currently, "make test" crashes if XDebug is not installed, and we want
to let people be able to run tests without coverage.

Proof PR: https://github.com/sonata-project/SonataAdminBundle/pull/5450