### PR TITLE
Use Ubuntu Xenial

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -23,8 +23,7 @@ services:
 {% endfor %}
 
 {% endif %}
-sudo: false
-dist: trusty
+dist: xenial
 
 addons:
   apt:


### PR DESCRIPTION
It should be faster for several reasons:
- preinstalled versions of php
- fewer services started

I also removed "sudo: false" because I think it might be the default
now.
See https://docs.travis-ci.com/user/reference/xenial/

Proof PR: https://github.com/sonata-project/SonataAdminBundle/pull/5451