### PR TITLE
Drop php 7.1 from datagrid 3.x

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -140,7 +140,7 @@ datagrid-bundle:
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.2', '7.3']
       versions:
         symfony: ['3.4']
 


### PR DESCRIPTION
It was never supposed to be supported.