### PR TITLE
Allow Travis CI to build on PHP 7.4

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -1,14 +1,14 @@
 admin-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_block: ['3']
         symfony_maker: ['1.7']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -18,13 +18,13 @@ admin-bundle:
 admin-search-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
         ruflin_elastica: ['2']
     1.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
@@ -33,11 +33,11 @@ admin-search-bundle:
 article-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
     1.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
 
@@ -48,7 +48,7 @@ block-bundle:
       versions:
         symfony: ['4.3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -61,30 +61,30 @@ cache:
   docs_target: false
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
 
 cache-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
 
 classification-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
@@ -92,19 +92,19 @@ classification-bundle:
 classification-media-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
 
 comment-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -112,18 +112,18 @@ comment-bundle:
 core-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
 
 dashboard-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -133,11 +133,11 @@ dashboard-bundle:
 datagrid-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
 
@@ -147,20 +147,20 @@ doctrine-extensions:
   docs_target: false
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
     1.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
 
 doctrine-mongodb-admin-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       services: [mongodb]
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       services: [mongodb]
       versions:
         symfony: ['3.4']
@@ -169,13 +169,13 @@ doctrine-mongodb-admin-bundle:
 doctrine-orm-admin-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -186,13 +186,13 @@ doctrine-phpcr-admin-bundle:
     - phpunit.xml.dist
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
         sonata_block: ['3']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_admin: ['3']
@@ -201,22 +201,22 @@ doctrine-phpcr-admin-bundle:
 easy-extends-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
 
 ecommerce:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['2.8']
 
@@ -225,14 +225,14 @@ exporter:
     - README.md
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         doctrine_odm: ['1']
       services: [mongodb]
       phpunit_version: 8
     2.x:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         doctrine_odm: ['1']
@@ -242,13 +242,13 @@ exporter:
 formatter-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_block: ['3']
     4.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -260,10 +260,10 @@ form-extensions:
     - docs/requirements.txt
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       phpunit_version: 8
     1.x:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       phpunit_version: 8
 
 google-authenticator:
@@ -272,19 +272,19 @@ google-authenticator:
   docs_target: false
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
 
 intl-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_user: ['3']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_user: ['3']
@@ -292,7 +292,7 @@ intl-bundle:
 media-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       services: [mongodb]
       versions:
         symfony: ['3.4']
@@ -300,7 +300,7 @@ media-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       services: [mongodb]
       versions:
         symfony: ['3.4']
@@ -311,13 +311,13 @@ media-bundle:
 news-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -326,12 +326,12 @@ news-bundle:
 notification-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -339,14 +339,14 @@ notification-bundle:
 page-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -360,13 +360,13 @@ sandbox:
 seo-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_block: ['3']
@@ -375,14 +375,14 @@ seo-bundle:
 timeline-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -392,13 +392,13 @@ timeline-bundle:
 translation-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         sonata_core: ['3']
@@ -410,21 +410,21 @@ twig-extensions:
     - docs/requirements.txt
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
     1.x:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
 
 user-bundle:
   branches:
     master:
-      php: ['7.2', '7.3']
+      php: ['7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         fos_user: ['2']
         sonata_core: ['3']
         sonata_admin: ['3']
     4.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.1', '7.2', '7.3', '7.4snapshot']
       versions:
         symfony: ['3.4']
         fos_user: ['2']

--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -67,6 +67,7 @@ matrix:
     - php: '{{ php|last }}'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
+    - php: 7.4snapshot
     - php: nightly
     - env: SYMFONY_DEPRECATIONS_HELPER=0
 {% for package_name,package_versions in versions %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Allow Travis CI to build on PHP 7.4.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change doesn't affect BC.