### PR TITLE
Remove "sonata-project/core-bundle" from DevKit

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -109,17 +109,6 @@ comment-bundle:
         symfony: ['3.4']
         sonata_core: ['3']
 
-core-bundle:
-  branches:
-    master:
-      php: ['7.2', '7.3']
-      versions:
-        symfony: ['3.4']
-    3.x:
-      php: ['7.1', '7.2', '7.3']
-      versions:
-        symfony: ['3.4']
-
 dashboard-bundle:
   branches:
     master:


### PR DESCRIPTION
This PR removes "sonata-project/core-bundle" from DevKit, as suggested at https://github.com/sonata-project/SonataCoreBundle/pull/711#issuecomment-524720014.