### PR TITLE
Add mongo service to doctrine-extensions build

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -138,8 +138,10 @@ doctrine-extensions:
   branches:
     master:
       php: ['7.2', '7.3', '7.4snapshot']
+      services: [mongodb]
     1.x:
       php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      services: [mongodb]
 
 doctrine-mongodb-admin-bundle:
   branches:


### PR DESCRIPTION
Required for this one: https://github.com/sonata-project/sonata-doctrine-extensions/pull/148