### PR TITLE
Stop testing sonata-project/user-bundle 3

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -282,12 +282,10 @@ intl-bundle:
       php: ['7.2', '7.3']
       versions:
         symfony: ['3.4']
-        sonata_user: ['3']
     2.x:
       php: ['7.1', '7.2', '7.3']
       versions:
         symfony: ['3.4']
-        sonata_user: ['3']
 
 media-bundle:
   branches:

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -137,7 +137,7 @@ datagrid-bundle:
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['7.1', '7.2', '7.3']
+      php: ['7.2', '7.3']
       versions:
         symfony: ['3.4']
 

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -104,7 +104,6 @@ abstract class AbstractCommand extends Command
     /**
      * Returns repository name without vendor prefix.
      *
-     *
      * @return string
      */
     final protected function getRepositoryName(Package $package)


### PR DESCRIPTION
It requires symfony components in version 2.8, and we are currently
trying to drop that version.