### PR TITLE
Use phpunit 8 for twig-extensions

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -460,9 +460,11 @@ twig-extensions:
     master:
       php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
+      phpunit_version: 8
     1.x:
       php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
+      phpunit_version: 8
 
 user-bundle:
   branches:


### PR DESCRIPTION
It looks like travis in https://github.com/sonata-project/twig-extensions/pull/47 would pass with phpunit 8