### PR TITLE
Explicit test symfony 5

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -53,13 +53,13 @@ block-bundle:
       php: ['7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
-        symfony: ['4.3']
+        symfony: ['4.3', '5.0']
       phpunit_version: 8
     4.x:
       php: ['7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
-        symfony: ['4.3']
+        symfony: ['4.3', '5.0']
       phpunit_version: 8
 
 cache:


### PR DESCRIPTION
When requiring symfony using the pipe operator (`^4.3 || ^5.0`), we could use the lowest symfony version. 
This PR will force symfony 5 for the block bundle.