### PR TITLE
Remove symfony/maker-bundle package from Travis

### DIFF
--- a/config/dev-kit.yml
+++ b/config/dev-kit.yml
@@ -44,7 +44,6 @@ labels:
 
 packages:
   symfony: symfony/symfony
-  symfony_maker: symfony/maker-bundle
   fos_user: friendsofsymfony/user-bundle
   sonata_core: sonata-project/core-bundle
   sonata_admin: sonata-project/admin-bundle

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -7,7 +7,6 @@ admin-bundle:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_block: ['3']
-        symfony_maker: ['1.7']
     3.x:
       php: ['7.1', '7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
@@ -15,7 +14,6 @@ admin-bundle:
         symfony: ['3.4']
         sonata_core: ['3']
         sonata_block: ['3']
-        symfony_maker: ['1.7']
 
 admin-search-bundle:
   branches:

--- a/project/.travis/before_install_test.sh.twig
+++ b/project/.travis/before_install_test.sh.twig
@@ -17,12 +17,5 @@ composer require "alcaeus/mongo-php-adapter"
 sed --in-place "s/\"dev-master\":/\"dev-${TRAVIS_COMMIT}\":/" composer.json
 
 {% for package_name,package_versions in versions if package_versions|length > 0 %}
-    {% if packages[package_name] == 'symfony/maker-bundle' %}
-# TODO: remove when dropping sf < 3.4 support
-if [[ -z "${SYMFONY}" || ("${SYMFONY:0:3}" != "2.8" && "${SYMFONY:0:3}" != "3.3") ]]; then
-    composer require "{{ "symfony/maker-bundle:${" ~ package_name|upper ~ ":=" ~ package_versions|first ~ "}"}}" --no-update
-fi
-    {% else %}
 if [ "${{ package_name|upper }}" != "" ]; then composer require "{{ packages[package_name] }}:${{ package_name|upper }}" --no-update; fi;
-    {% endif %}
 {% endfor %}


### PR DESCRIPTION
Since [it is explicitly required in SonataAdminBundle](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/composer.json#L71), I don't think this is needed anymore