### PR TITLE
Drop PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
 
 language: php
 
-php: 7.1
+php: 7.3
 
 sudo: false
 

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -9,7 +9,7 @@ admin-bundle:
         sonata_block: ['3']
         symfony_maker: ['1.7']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -27,7 +27,7 @@ admin-search-bundle:
         sonata_admin: ['3']
         ruflin_elastica: ['2']
     1.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -42,7 +42,7 @@ article-bundle:
       versions:
         symfony: ['3.4']
     1.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -71,7 +71,7 @@ cache:
       php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
     2.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
 
 cache-bundle:
@@ -82,7 +82,7 @@ cache-bundle:
       versions:
         symfony: ['3.4']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -97,7 +97,7 @@ classification-bundle:
         sonata_admin: ['3']
       services: [mongodb]
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -121,7 +121,7 @@ comment-bundle:
         symfony: ['3.4']
         sonata_core: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -161,7 +161,7 @@ doctrine-extensions:
       target_php: '7.3'
       services: [mongodb]
     1.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       services: [mongodb]
 
@@ -175,7 +175,7 @@ doctrine-mongodb-admin-bundle:
         symfony: ['3.4']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       services: [mongodb]
       versions:
@@ -192,7 +192,7 @@ doctrine-orm-admin-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -211,7 +211,7 @@ doctrine-phpcr-admin-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
     2.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -226,7 +226,7 @@ easy-extends-bundle:
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -275,7 +275,7 @@ formatter-bundle:
         sonata_core: ['3']
         sonata_block: ['3']
     4.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -305,7 +305,7 @@ google-authenticator:
       php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
     2.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
 
 intl-bundle:
@@ -316,7 +316,7 @@ intl-bundle:
       versions:
         symfony: ['3.4']
     2.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -334,7 +334,7 @@ media-bundle:
         sonata_admin: ['3']
         imagine: ['0.7', '1']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       services: [mongodb]
       versions:
@@ -354,7 +354,7 @@ news-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -370,7 +370,7 @@ notification-bundle:
         symfony: ['3.4']
         sonata_core: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -387,7 +387,7 @@ page-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -409,7 +409,7 @@ seo-bundle:
         sonata_block: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -427,7 +427,7 @@ timeline-bundle:
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -445,7 +445,7 @@ translation-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']
@@ -477,7 +477,7 @@ user-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
     4.x:
-      php: ['7.1', '7.2', '7.3', '7.4snapshot']
+      php: ['7.2', '7.3', '7.4snapshot']
       target_php: '7.3'
       versions:
         symfony: ['3.4']


### PR DESCRIPTION
As Travis CI does not support PHP 7.4 atm, this PR will just drop PHP 7.1 which is unsupported now.