### PR TITLE
Use PHPUnit 8 for SonataMediaBundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -331,6 +331,7 @@ media-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
         imagine: ['0.7', '1']
+      phpunit_version: 8
     3.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
@@ -341,6 +342,7 @@ media-bundle:
         sonata_core: ['3']
         sonata_admin: ['3']
         imagine: ['0.7', '1']
+      phpunit_version: 8
 
 news-bundle:
   branches:


### PR DESCRIPTION
After https://github.com/sonata-project/SonataMediaBundle/pull/1661, SonataMediaBundle needs PHPUnit 8