### PR TITLE
Remove CoreBundle test for master branches

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -5,7 +5,6 @@ admin-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
         sonata_block: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
@@ -117,7 +116,6 @@ comment-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
@@ -132,7 +130,6 @@ dashboard-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
 
@@ -187,7 +184,6 @@ doctrine-orm-admin-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
@@ -270,7 +266,6 @@ formatter-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
         sonata_block: ['3']
     4.x:
       php: ['7.2', '7.3', '7.4']
@@ -328,7 +323,6 @@ media-bundle:
       versions:
         symfony: ['3.4']
         doctrine_odm: ['1']
-        sonata_core: ['3']
         sonata_admin: ['3']
         imagine: ['0.7', '1']
     3.x:
@@ -349,7 +343,6 @@ news-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
         sonata_admin: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
@@ -366,7 +359,6 @@ notification-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
@@ -381,7 +373,6 @@ page-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
@@ -421,7 +412,6 @@ timeline-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
@@ -440,7 +430,6 @@ translation-bundle:
       target_php: '7.3'
       versions:
         symfony: ['3.4']
-        sonata_core: ['3']
         sonata_admin: ['3']
     2.x:
       php: ['7.2', '7.3', '7.4']
@@ -472,7 +461,6 @@ user-bundle:
       versions:
         symfony: ['3.4']
         fos_user: ['2']
-        sonata_core: ['3']
         sonata_admin: ['3']
     4.x:
       php: ['7.2', '7.3', '7.4']


### PR DESCRIPTION
The next major version for each bundle should not use the CoreBundle. This PR removes all `master` branch tests for the CoreBundle to make the development process faster.