### PR TITLE
Use PHPUnit 8 for master branch of SonataAdminBundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -2,6 +2,7 @@ admin-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
+      phpunit_version: 8
       target_php: '7.3'
       versions:
         symfony: ['3.4']


### PR DESCRIPTION
Apart from https://github.com/sonata-project/dev-kit/pull/535, this is also needed for https://github.com/sonata-project/SonataAdminBundle/pull/5787