### PR TITLE
Drop testing php 7.2 in master branch of SonataAdminBundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -1,7 +1,7 @@
 admin-bundle:
   branches:
     master:
-      php: ['7.2', '7.3', '7.4']
+      php: ['7.3', '7.4']
       phpunit_version: 8
       target_php: '7.3'
       versions:


### PR DESCRIPTION
It will [use SonataBlockBundle which the requirement is `^7.3`](https://github.com/sonata-project/SonataBlockBundle/blob/4.x/composer.json#L23)