### PR TITLE
Introduce stale label

### DIFF
--- a/config/dev-kit.yml
+++ b/config/dev-kit.yml
@@ -21,6 +21,8 @@ labels:
     color: 'ededed'
   - name: pending author
     color: 'ededed'
+  - name: stale
+    color: 'ededed'
   - name: in progress
     color: 'ededed'
   - name: RTM

--- a/project/.github/workflows/stale.yml
+++ b/project/.github/workflows/stale.yml
@@ -18,12 +18,12 @@ jobs:
           days-before-stale: 180
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           exempt-issue-label: "keep"
-          stale-issue-label: "pending author"
+          stale-issue-label: "stale"
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you
             for your contributions.
-          stale-pr-label: "pending author"
+          stale-pr-label: "stale"
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you


### PR DESCRIPTION
We should not use `pending author` for stale. Otherwise issues / PRs labeled by SonataCI would be closed after 7 days.

Stale will now mark issues / PRs without any action as `stale` after 180 days. When an the issue / PR is labeled 7 days as `stale`, it will be closed.