### PR TITLE
Remove testing Symfony 5 in SonataAdminBundle master branch

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -4,7 +4,7 @@ admin-bundle:
       php: ['7.3', '7.4']
       target_php: '7.3'
       versions:
-        symfony: ['4.4', '5.0']
+        symfony: ['4.4']
     3.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'


### PR DESCRIPTION
https://github.com/sonata-project/SonataAdminBundle/pull/5836 is failing because of this, `master` branch is still not supporting Symfony 5