### PR TITLE
Remove old stale file

### DIFF
--- a/project/.github/DELETE_stale.yml
+++ b/project/.github/DELETE_stale.yml
@@ -1,0 +1,1 @@
+_extends: dev-kit


### PR DESCRIPTION
IIRC this was only needed for the Stale-Marketplace-App, but now we use a GithubAction