### PR TITLE
Fix .gitignore

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -1,62 +1,62 @@
 admin-bundle:
   custom_gitignore_part: |
     # clean up some non bower ready package
-    Resources/public/vendor/admin-lte/bootstrap
-    Resources/public/vendor/admin-lte/build
-    Resources/public/vendor/admin-lte/dist/img
-    !Resources/public/vendor/admin-lte/dist/img/boxed-bg.jpg # Only image called in AdminLTe.css
-    Resources/public/vendor/admin-lte/dist/js/app.js
-    Resources/public/vendor/admin-lte/dist/js/demo.js
-    Resources/public/vendor/admin-lte/dist/js/pages
-    Resources/public/vendor/admin-lte/documentation
-    Resources/public/vendor/admin-lte/pages
-    Resources/public/vendor/admin-lte/plugins
-    Resources/public/vendor/admin-lte/*.html
-    Resources/public/vendor/admin-lte/Gruntfile.js
+    src/Resources/public/vendor/admin-lte/bootstrap
+    src/Resources/public/vendor/admin-lte/build
+    src/Resources/public/vendor/admin-lte/dist/img
+    !src/Resources/public/vendor/admin-lte/dist/img/boxed-bg.jpg # Only image called in AdminLTe.css
+    src/Resources/public/vendor/admin-lte/dist/js/app.js
+    src/Resources/public/vendor/admin-lte/dist/js/demo.js
+    src/Resources/public/vendor/admin-lte/dist/js/pages
+    src/Resources/public/vendor/admin-lte/documentation
+    src/Resources/public/vendor/admin-lte/pages
+    src/Resources/public/vendor/admin-lte/plugins
+    src/Resources/public/vendor/admin-lte/*.html
+    src/Resources/public/vendor/admin-lte/Gruntfile.js
 
-    Resources/public/vendor/iCheck/skins/all.css
-    Resources/public/vendor/iCheck/skins/*/*
-    !Resources/public/vendor/iCheck/skins/square/blue.css
-    !Resources/public/vendor/iCheck/skins/square/blue.png
-    !Resources/public/vendor/iCheck/skins/square/blue@2x.png
-    Resources/public/vendor/iCheck/icheck.js
+    src/Resources/public/vendor/iCheck/skins/all.css
+    src/Resources/public/vendor/iCheck/skins/*/*
+    !src/Resources/public/vendor/iCheck/skins/square/blue.css
+    !src/Resources/public/vendor/iCheck/skins/square/blue.png
+    !src/Resources/public/vendor/iCheck/skins/square/blue@2x.png
+    src/Resources/public/vendor/iCheck/icheck.js
 
-    Resources/public/vendor/slimScroll/examples
-    Resources/public/vendor/slimScroll/jquery.slimscroll.js
+    src/Resources/public/vendor/slimScroll/examples
+    src/Resources/public/vendor/slimScroll/jquery.slimscroll.js
 
-    Resources/public/vendor/bootstrap/grunt
-    Resources/public/vendor/bootstrap/less
-    Resources/public/vendor/bootstrap/test-infra
-    Resources/public/vendor/bootstrap/Gruntfile.js
+    src/Resources/public/vendor/bootstrap/grunt
+    src/Resources/public/vendor/bootstrap/less
+    src/Resources/public/vendor/bootstrap/test-infra
+    src/Resources/public/vendor/bootstrap/Gruntfile.js
 
-    Resources/public/vendor/jqueryui/themes/black-tie
-    Resources/public/vendor/jqueryui/themes/blitzer
-    Resources/public/vendor/jqueryui/themes/cupertino
-    Resources/public/vendor/jqueryui/themes/dark-hive
-    Resources/public/vendor/jqueryui/themes/dot-luv
-    Resources/public/vendor/jqueryui/themes/eggplant
-    Resources/public/vendor/jqueryui/themes/excite-bike
-    Resources/public/vendor/jqueryui/themes/hot-sneaks
-    Resources/public/vendor/jqueryui/themes/humanity
-    Resources/public/vendor/jqueryui/themes/le-frog
-    Resources/public/vendor/jqueryui/themes/mint-choc
-    Resources/public/vendor/jqueryui/themes/overcast
-    Resources/public/vendor/jqueryui/themes/pepper-grinder
-    Resources/public/vendor/jqueryui/themes/redmond
-    Resources/public/vendor/jqueryui/themes/smoothness
-    Resources/public/vendor/jqueryui/themes/south-street
-    Resources/public/vendor/jqueryui/themes/start
-    Resources/public/vendor/jqueryui/themes/sunny
-    Resources/public/vendor/jqueryui/themes/swanky-purse
-    Resources/public/vendor/jqueryui/themes/trontastic
-    Resources/public/vendor/jqueryui/themes/ui-darkness
-    Resources/public/vendor/jqueryui/themes/ui-lightness
-    Resources/public/vendor/jqueryui/themes/vader
+    src/Resources/public/vendor/jqueryui/themes/black-tie
+    src/Resources/public/vendor/jqueryui/themes/blitzer
+    src/Resources/public/vendor/jqueryui/themes/cupertino
+    src/Resources/public/vendor/jqueryui/themes/dark-hive
+    src/Resources/public/vendor/jqueryui/themes/dot-luv
+    src/Resources/public/vendor/jqueryui/themes/eggplant
+    src/Resources/public/vendor/jqueryui/themes/excite-bike
+    src/Resources/public/vendor/jqueryui/themes/hot-sneaks
+    src/Resources/public/vendor/jqueryui/themes/humanity
+    src/Resources/public/vendor/jqueryui/themes/le-frog
+    src/Resources/public/vendor/jqueryui/themes/mint-choc
+    src/Resources/public/vendor/jqueryui/themes/overcast
+    src/Resources/public/vendor/jqueryui/themes/pepper-grinder
+    src/Resources/public/vendor/jqueryui/themes/redmond
+    src/Resources/public/vendor/jqueryui/themes/smoothness
+    src/Resources/public/vendor/jqueryui/themes/south-street
+    src/Resources/public/vendor/jqueryui/themes/start
+    src/Resources/public/vendor/jqueryui/themes/sunny
+    src/Resources/public/vendor/jqueryui/themes/swanky-purse
+    src/Resources/public/vendor/jqueryui/themes/trontastic
+    src/Resources/public/vendor/jqueryui/themes/ui-darkness
+    src/Resources/public/vendor/jqueryui/themes/ui-lightness
+    src/Resources/public/vendor/jqueryui/themes/vader
 
-    Resources/public/vendor/jquery/src
+    src/Resources/public/vendor/jquery/src
 
-    Resources/public/vendor/jquery.scrollTo/demo
-    Resources/public/vendor/jquery.scrollTo/tests
+    src/Resources/public/vendor/jquery.scrollTo/demo
+    src/Resources/public/vendor/jquery.scrollTo/tests
 
   branches:
     master:


### PR DESCRIPTION
Based on https://github.com/sonata-project/SonataAdminBundle/pull/5922/files#r384943906

EDIT:
Strange, in `3.x` we don't start the paths with `src`:
https://github.com/sonata-project/SonataAdminBundle/pull/5900/files#diff-a084b794bc0759e7a6b77810e01874f2

Shall we remove the `src/` prefix or add it ?