### PR TITLE
Test PHP 7.4 in Travis

### DIFF
--- a/project/.travis.yml.twig
+++ b/project/.travis.yml.twig
@@ -50,7 +50,7 @@ matrix:
       env: {{ package_name|upper }}='dev-master as {{ package_versions|last }}.x-dev'
 {% endif %}
 {% endfor %}
-    - php: '{{ target_php|default(php|last) }}'
+    - php: '{{ php|last }}'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
     - php: nightly


### PR DESCRIPTION
From the `php` array config, we are not testing with the last item, so [we are not testing with PHP 7.4](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/.travis.yml#L47). This was changed in https://github.com/sonata-project/dev-kit/pull/515 to fix an error. Now every project has `target_php` defined.