### PR TITLE
Add "logical_operators" to PHP CS Fixer rules

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -26,6 +26,7 @@ $rules = [
     'header_comment' => [
         'header' => $header,
     ],
+    'logical_operators' => true,
     'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
     'no_extra_blank_lines' => true,
     'no_php4_constructor' => true,

--- a/project/.php_cs.dist.twig
+++ b/project/.php_cs.dist.twig
@@ -26,6 +26,7 @@ $rules = [
     'header_comment' => [
         'header' => $header,
     ],
+    'logical_operators' => true,
     'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
     'no_extra_blank_lines' => true,
     'no_php4_constructor' => true,


### PR DESCRIPTION
This rule should cover cases like this: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/839#discussion_r259950505.