### PR TITLE
Enhancement: Auto-Merge dependabot PR's again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,11 +58,11 @@ jobs:
         if: >
             github.event_name == 'pull_request' &&
             github.event.pull_request.draft == false && (
-              github.event.action == 'opened' ||
-              github.event.action == 'reopened' ||
-              github.event.action == 'synchronize'
+                github.event.action == 'opened' ||
+                github.event.action == 'reopened' ||
+                github.event.action == 'synchronize'
             ) && (
-              github.actor == 'dependabot[bot]'
+                github.actor == 'dependabot[bot]'
             )
 
         steps:
@@ -75,8 +75,8 @@ jobs:
                       const repository = context.repo
 
                       await github.pulls.merge({
-                        merge_method: "merge",
-                        owner: repository.owner,
-                        pull_number: pullRequest.number,
-                        repo: repository.repo,
+                          merge_method: "merge",
+                          owner: repository.owner,
+                          pull_number: pullRequest.number,
+                          repo: repository.repo,
                       })

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,3 +44,39 @@ jobs:
               uses: "docker://oskarstark/phpstan-ga"
               with:
                   args: analyse
+
+    auto-merge:
+        name: "Auto-Merge"
+
+        runs-on: "ubuntu-latest"
+
+        needs:
+            - "php-cs-fixer"
+            - "composer-normalize"
+            - "phpstan"
+
+        if: >
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.draft == false && (
+              github.event.action == 'opened' ||
+              github.event.action == 'reopened' ||
+              github.event.action == 'synchronize'
+            ) && (
+              github.actor == 'dependabot[bot]'
+            )
+
+        steps:
+            - name: "Merge pull request"
+              uses: "actions/github-script@v2"
+              with:
+                  github-token: "$"
+                  script: |
+                      const pullRequest = context.payload.pull_request
+                      const repository = context.repo
+
+                      await github.pulls.merge({
+                        merge_method: "merge",
+                        owner: repository.owner,
+                        pull_number: pullRequest.number,
+                        repo: repository.repo,
+                      })

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
             - name: "Merge pull request"
               uses: "actions/github-script@v2"
               with:
-                  github-token: "$"
+                  github-token: "${{ secrets.SONATA_CI_GITHUB_TOKEN }}"
                   script: |
                       const pullRequest = context.payload.pull_request
                       const repository = context.repo

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,8 @@ jobs:
         runs-on: "ubuntu-latest"
 
         needs:
-            - "php-cs-fixer"
             - "composer-normalize"
+            - "php-cs-fixer"
             - "phpstan"
 
         if: >


### PR DESCRIPTION
@localheinz wrote:
> When you follow the instructions, you will find that the migration is straightforward. However, there is one thing missing: after migrating from version 1 to version 2, Dependabot will not automatically merge pull requests anymore.

For reference: https://localheinz.com/blog/2020/06/15/merging-pull-requests-with-github-actions/