### PR TITLE
Fix twig-extension doc build

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -447,8 +447,6 @@ translation-bundle:
 
 twig-extensions:
   docs_target: false
-  excluded_files:
-    - docs/requirements.txt
   branches:
     master:
       php: ['7.2', '7.3', '7.4']

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -298,8 +298,6 @@ formatter-bundle:
 
 form-extensions:
   docs_target: false
-  excluded_files:
-    - docs/requirements.txt
   branches:
     master:
       php: ['7.2', '7.3', '7.4']


### PR DESCRIPTION
This change will allow generate documentation for twig-extension without build fail.