### PR TITLE
Revert support for 3.x BlockBundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -114,6 +114,13 @@ block-bundle:
       target_php: '7.3'
       versions:
         symfony: ['4.4', '5.0']
+    3.x:
+      php: ['7.2', '7.3', '7.4']
+      target_php: '7.3'
+      versions:
+        symfony: ['4.4']
+        sonata_admin: ['3']
+        sonata_core: ['3']
 
 classification-bundle:
   branches:


### PR DESCRIPTION
This branch should be suppport as long as Sonata 4 is not finish.