### PR TITLE
Add consistency in versions checked by the ci

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -64,6 +64,7 @@ admin-bundle:
       target_php: '7.3'
       versions:
         symfony: ['4.4']
+        sonata_block: ['4']
     3.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
@@ -118,7 +119,6 @@ block-bundle:
       target_php: '7.3'
       versions:
         symfony: ['4.4']
-        sonata_admin: ['3']
 
 classification-bundle:
   branches:
@@ -222,6 +222,7 @@ doctrine-orm-admin-bundle:
       target_php: '7.3'
       versions:
         symfony: ['4.4']
+        sonata_admin: ['dev-master']
     3.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'


### PR DESCRIPTION
Following https://github.com/sonata-project/dev-kit/pull/793 and https://github.com/sonata-project/dev-kit/pull/784.

There is currently some conflict on SonataAdmin 3.x vs master.
One of them is because we have a special check for SonataAdmin v3 with SonataBlock v3 but none on master.

I added
```
versions:
        sonata_block: ['4']
```
To have a similar check, this way it leads to less futur conflict.

In a similar way, I remove the `sonataAdmin: 3` check on sonataBlock since sonataAdmin is not a dependency of SonataBlock.

And I re-add the SonataAdmin version check on doctrine-orm-admin-bundle, but I'll try with `dev-master`.
This is more consistent, and can be used as a reminder to change this to 4 after the next major.

WDYT ?