### PR TITLE
Add user-bundle build to sonata-intl-bundle

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -331,6 +331,7 @@ intl-bundle:
       target_php: '7.3'
       versions:
         symfony: ['4.4']
+        sonata_user: ['4']
 
 media-bundle:
   branches:


### PR DESCRIPTION
Required by this PR: https://github.com/sonata-project/SonataIntlBundle/pull/308

The thing is, the user-bundle is a dev requirement on SonataIntlBundle because it has some code that is deprecated (and removed on master already). So in order to add Symfony 5 compat (and Twig 3) we need to remove that require dev and add a build with user-bundle (to check that everything is still working, even if it is deprecated).