### PR TITLE
Use constructor injection instead of creating new instance

### DIFF
--- a/src/Command/DispatchCommand.php
+++ b/src/Command/DispatchCommand.php
@@ -24,7 +24,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use function Symfony\Component\String\u;
 use Twig\Environment;
-use Twig\Loader\FilesystemLoader;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -53,6 +52,15 @@ final class DispatchCommand extends AbstractNeedApplyCommand
      */
     private $projects;
 
+    public function __construct(GitWrapper $gitWrapper, Filesystem $fileSystem, Environment $twig)
+    {
+        parent::__construct();
+
+        $this->gitWrapper = $gitWrapper;
+        $this->fileSystem = $fileSystem;
+        $this->twig = $twig;
+    }
+
     protected function configure(): void
     {
         parent::configure();
@@ -68,10 +76,6 @@ final class DispatchCommand extends AbstractNeedApplyCommand
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
-
-        $this->gitWrapper = new GitWrapper();
-        $this->fileSystem = new Filesystem();
-        $this->twig = new Environment(new FilesystemLoader(__DIR__.'/../..'));
 
         $this->projects = \count($input->getArgument('projects'))
             ? $input->getArgument('projects')


### PR DESCRIPTION
Related to https://github.com/sonata-project/dev-kit/pull/797#issuecomment-667840068

The freshly created twig extension is not know by the TwigEnvironment used by this command.
Instead of creating new instance of service in the initialize method, I use dependency injection instead.

This may fix the issue, but I don't know how to try...