### PR TITLE
Test Symfony 5.1 in extensions

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -304,9 +304,13 @@ form-extensions:
     master:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
+      versions:
+        symfony: ['4.4', '5.1']
     1.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
+      versions:
+        symfony: ['4.4', '5.1']
 
 google-authenticator:
   excluded_files:
@@ -326,7 +330,7 @@ intl-bundle:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
       versions:
-        symfony: ['4.4']
+        symfony: ['4.4', '5.1']
     2.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
@@ -457,9 +461,13 @@ twig-extensions:
     master:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
+      versions:
+        symfony: ['4.4', '5.1']
     1.x:
       php: ['7.2', '7.3', '7.4']
       target_php: '7.3'
+      versions:
+        symfony: ['4.4', '5.1']
 
 user-bundle:
   branches:


### PR DESCRIPTION
The Symfony version is not specified in the extensions (twig, doctrine and forms) I don't know if there was a reason, I'll make PR to bump to 5.1 to these packages.

**EDIT**: I've remove symfony version in sonata-doctrine-extensions since it doesn't require any symfony packages.

https://github.com/sonata-project/form-extensions/pull/111
https://github.com/sonata-project/twig-extensions/pull/101