### PR TITLE
Fix dispatch command

### DIFF
--- a/src/Command/DispatchCommand.php
+++ b/src/Command/DispatchCommand.php
@@ -494,7 +494,7 @@ final class DispatchCommand extends AbstractNeedApplyCommand
         }
 
         $branchConfig = $projectConfig['branches'][$branchName];
-        $localPathInfo = pathinfo($localPath);
+        $localPathInfo = pathinfo($localFullPath);
 
         if (u($localPathInfo['basename'])->startsWith('DELETE_')) {
             $fileToDelete = u($distPath)->replace('DELETE_', '')->toString();
@@ -544,6 +544,6 @@ final class DispatchCommand extends AbstractNeedApplyCommand
         }
 
         // Restore file permissions after content copy
-        $this->fileSystem->chmod($distPath, fileperms($localPath));
+        $this->fileSystem->chmod($distPath, fileperms($localFullPath));
     }
 }


### PR DESCRIPTION
The dispatch command is currently failing because of an error ligne 527.

I think it's because the `fileperms` method does not find the file since I move it inside the template dir.
So I replace every usage of the relative path by the full path.

Moreover, I find a check
```
\in_array(substr($localPath, 8), $projectConfig['excluded_files'], true)) {
```
This only works if the dir is called `project` (7 letters, 8 with the `/` symbol).

So I preferred to
- create a constant for the `project` dir.
- add a check at the start of the `renderFile` that the local path is starting by `project/`.