### PR TITLE
add static-analysis folder to export-ignore

### DIFF
--- a/templates/project/.gitattributes.twig
+++ b/templates/project/.gitattributes.twig
@@ -4,5 +4,6 @@
 
 .* export-ignore
 *.md export-ignore
+ci/ export-ignore
 {{ tests_path }} export-ignore
 {{ docs_path }} export-ignore


### PR DESCRIPTION
During conversation here https://github.com/sonata-project/SonataAdminBundle/pull/6288#issuecomment-674423078 we found that it will be useful for us to have separate folder for static analysis which will be excluded from publishing to packagist.