### PR TITLE
Shorter slack warning

### DIFF
--- a/src/Command/AutoMergeCommand.php
+++ b/src/Command/AutoMergeCommand.php
@@ -124,10 +124,10 @@ final class AutoMergeCommand extends AbstractNeedApplyCommand
                 }
             } catch (RuntimeException $e) {
                 if (409 === $e->getCode()) {
-                    $message = sprintf('Merging of %s into %s contains conflicts. Skipped.', $head, $base);
+                    $message = sprintf('%s: Merging of %s into %s contains conflicts. Skipped.', $repositoryName, $head, $base);
 
                     $this->io->warning($message);
-                    $this->logger->warning($message, ['repository' => $repositoryName]);
+                    $this->logger->warning($message);
 
                     continue;
                 }


### PR DESCRIPTION
Proposal to get an even shorter slack message.

From
```
Warning
Merging of 2.x into master contains conflicts. Skipped.
Context
{
    "repository": "SonataIntlBundle"
}
```

To 
```
Warning
SonataIntlBundle: Merging of 2.x into master contains conflicts. Skipped.
```