### PR TITLE
Remove development files from Composer package

### DIFF
--- a/templates/project/.gitattributes.twig
+++ b/templates/project/.gitattributes.twig
@@ -6,3 +6,7 @@
 *.md export-ignore
 {{ tests_path }} export-ignore
 {{ docs_path }} export-ignore
+Makefile export-ignore
+phpstan-baseline.neon export-ignore
+phpstan.neon.dist export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
In https://github.com/sonata-project/dev-kit/pull/130#issuecomment-229588693 it was suggested to remove Makefile and phpunit.xml.dist from the Composer package. Although this seems everyone agreed, these filenames were not added to .gitattributes.

In this PR this is fixed and I also exclude the phpstan files that have been added to some Sonata projects since then.