### PR TITLE
Add mongodb compatibility layer

### DIFF
--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -22,6 +22,12 @@ jobs:
 
     {% verbatim %}continue-on-error: ${{ matrix.allowed_to_fail }}{% endverbatim %}
 
+{% if 'mongodb' in services %}
+    services:
+      mongo:
+        image: mongo
+
+{% endif %}
     strategy:
       matrix:
         php-version:
@@ -48,7 +54,7 @@ jobs:
             variant: '{{ packages[package_name] }}:"{{ version }}{% if not is_dev_branch(version) %}.*{% endif %}"'
 {% endfor %}
 {% endfor %}
-{% verbatim %}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -56,12 +62,17 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
           coverage: pcov
+{% if 'mongodb' in services %}
+          tools: composer:v2, pecl
+          extensions: mongodb
+{% else %}
           tools: composer:v2
+{% endif %}
 
       - name: Add PHPUnit matcher
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+        {% verbatim %}run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"{% endverbatim %}
 
       - name: Set Composer cache directory
         id: composer-cache
@@ -70,13 +81,19 @@ jobs:
       - name: Cache Composer
         uses: actions/cache@v2
         with:
+{%- verbatim %}
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
           restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
+{% endverbatim %}
+{% if 'mongodb' in services %}
+      - name: Install mongo compatibility layer
+        run: composer require alcaeus/mongo-php-adapter --no-update
 
+{% endif %}
       - name: Install variant
         if: matrix.variant != 'normal'
-        run: composer require ${{ matrix.variant }} --no-update
+        {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
 
       - name: Install Composer dependencies (lowest)
         if: matrix.dependencies == 'lowest'
@@ -97,4 +114,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: build/logs/clover.xml
-{% endverbatim -%}


### PR DESCRIPTION
Diff for classification-bundle:

```diff
diff --git a/.github/workflows/test.yaml b/.github/workflows/test.yaml
index d03e772..3150e4f 100644
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,10 @@ jobs:

     continue-on-error: ${{ matrix.allowed_to_fail }}

+    services:
+      mongo:
+        image: mongo
+
     strategy:
       matrix:
         php-version:
@@ -57,7 +61,8 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: pcov
-          tools: composer:v2
+          tools: composer:v2, pecl
+          extensions: mongodb

       - name: Add PHPUnit matcher
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -73,6 +78,9 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
           restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-

+      - name: Install mongo compatibility layer
+        run: composer require alcaeus/mongo-php-adapter --no-update
+
       - name: Install variant
         if: matrix.variant != 'normal'
         run: composer require ${{ matrix.variant }} --no-update
```

Diff for admin-bundle:

```
sonata-project/admin-bundle
===========================

Files for 3.x
-------------

 // Nothing to be changed.
```