### PR TITLE
Fix mongodb tests

### DIFF
--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -26,6 +26,8 @@ jobs:
     services:
       mongo:
         image: mongo
+        ports:
+          - 27017:27017
 
 {% endif %}
     strategy:


### PR DESCRIPTION
Output for mongodb:

```diff
diff --git a/.github/workflows/test.yaml b/.github/workflows/test.yaml
index 3150e4f..6424545 100644
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,8 @@ jobs:
     services:
       mongo:
         image: mongo
+        ports:
+          - 27017:27017

     strategy:
       matrix:
```

Proof: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/398