### PR TITLE
Trigger build for xml.dist files

### DIFF
--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -12,7 +12,7 @@ on:
 {% endfor %}
 
   pull_request:
-    paths: ['**.php', '**.yml', '**.yaml', '**.xml', '**.twig', '**.js', '**.css', '**.json']
+    paths: ['**.php', '**.yml', '**.yaml', '**.xml', '**.xml.dist', '**.twig', '**.js', '**.css', '**.json']
 
 jobs:
   test:


### PR DESCRIPTION
xml.dist were not on relevant files for travis (that's where I copied the initial array), but they should be, because the phpunit.xml.dist is not an xml, but .xml.dist file