### PR TITLE
Remove unneeded target php version

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -61,13 +61,11 @@ admin-bundle:
   branches:
     master:
       php: ['7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_block: ['4']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_block: ['3']
@@ -76,14 +74,12 @@ admin-search-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
         ruflin_elastica: ['5', '6']
     1.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -93,12 +89,10 @@ article-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
     1.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
 
@@ -106,17 +100,14 @@ block-bundle:
   branches:
     master:
       php: ['7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
     4.x:
       php: ['7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
 
@@ -124,14 +115,12 @@ classification-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
       services: [mongodb]
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -141,7 +130,6 @@ classification-media-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
 
@@ -149,12 +137,10 @@ comment-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
 
@@ -165,7 +151,6 @@ dashboard-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -175,12 +160,10 @@ datagrid-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
 
@@ -191,25 +174,21 @@ doctrine-extensions:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       services: [mongodb]
     1.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       services: [mongodb]
 
 doctrine-mongodb-admin-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       services: [mongodb]
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       services: [mongodb]
       versions:
         symfony: ['4.4']
@@ -219,13 +198,11 @@ doctrine-orm-admin-bundle:
   branches:
     master:
       php: ['7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['dev-master']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -238,14 +215,12 @@ doctrine-phpcr-admin-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
         sonata_block: ['3']
     2.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -255,12 +230,10 @@ ecommerce:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
 
@@ -270,14 +243,12 @@ exporter:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         doctrine_odm: ['1']
       services: [mongodb]
     2.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         doctrine_odm: ['1']
@@ -287,13 +258,11 @@ formatter-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_block: ['3']
     4.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_block: ['3']
@@ -303,12 +272,10 @@ form-extensions:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
     1.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
 
@@ -319,21 +286,17 @@ google-authenticator:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
     2.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
 
 intl-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
     2.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
         sonata_user: ['4']
@@ -342,7 +305,6 @@ media-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       services: [mongodb]
       versions:
         symfony: ['4.4']
@@ -351,7 +313,6 @@ media-bundle:
         imagine: ['0.7', '1']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       services: [mongodb]
       versions:
         symfony: ['4.4']
@@ -363,13 +324,11 @@ news-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -378,12 +337,10 @@ notification-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
 
@@ -391,14 +348,12 @@ page-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -412,12 +367,10 @@ seo-bundle:
   branches:
     master:
       php: ['7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
     2.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_block: ['3']
@@ -427,14 +380,12 @@ timeline-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
         sonata_block: ['3']
     3.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -444,13 +395,11 @@ translation-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
     2.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         sonata_admin: ['3']
@@ -460,12 +409,10 @@ twig-extensions:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
     1.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4', '5.1']
 
@@ -473,14 +420,12 @@ user-bundle:
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         fos_user: ['2']
         sonata_admin: ['3']
     4.x:
       php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
       versions:
         symfony: ['4.4']
         fos_user: ['2']

--- a/src/Config/ProjectsConfiguration.php
+++ b/src/Config/ProjectsConfiguration.php
@@ -75,7 +75,7 @@ class ProjectsConfiguration implements ConfigurationInterface
         $builder = new TreeBuilder('versions');
         $node = $builder->getRootNode();
 
-        $childrenNode = $node->children();
+        $childrenNode = $node->addDefaultsIfNotSet()->children();
 
         foreach ($this->devKitConfigs['packages'] as $key => $name) {
             $childrenNode->arrayNode($key)->prototype('scalar')->defaultValue([])->end()->end();


### PR DESCRIPTION
Now all the variants execute with php 7.4

It was added when php 7.4 was on snapshot: https://github.com/sonata-project/dev-kit/pull/515

I didn't remove the config option because it might be useful in some cases, but when everything gets stable, we might remove it too. (on another PR)