### PR TITLE
Enhancement: Only docs if docs available

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -270,7 +270,6 @@ formatter-bundle:
         sonata_block: ['3']
 
 form-extensions:
-  docs_target: false
   branches:
     master:
       php: ['7.2', '7.3', '7.4']
@@ -415,7 +414,6 @@ translation-bundle:
         sonata_admin: ['3']
 
 twig-extensions:
-  docs_target: false
   branches:
     master:
       php: ['7.2', '7.3', '7.4']

--- a/templates/project/README.md.twig
+++ b/templates/project/README.md.twig
@@ -29,10 +29,12 @@ There is no active support on it.
 Feel free to ask if you want to help to keep this project up to date.
 
 {% endif %}
+{% if docs_target %}
 ## Documentation
 
 Check out the documentation on the [official website](https://sonata-project.org/bundles/{{ website_path }}).
 
+{% endif %}
 ## Support
 
 For general support and questions, please use [StackOverflow](http://stackoverflow.com/questions/tagged/sonata).


### PR DESCRIPTION
This PR

* [x] removes `/docs` folder from the repo/branch
* [x] removes the link in the `README.md` to the documentation
* [x] removes the workflow `documentation.yaml` file entirely
* [x] removes `DOCtor-RST` and `Sphinx build` from the required checks

 plus

* [x] added some command output for the required checks:
![Bildschirmfoto 2020-08-31 um 14 59 05](https://user-images.githubusercontent.com/995707/91722465-95dcfc00-eb9a-11ea-9ed8-f81a89990b53.png)


### Diff for `sonata-project/google-authenticator`
```diff
diff --git a/.github/workflows/documentation.yaml b/.github/workflows/documentation.yaml
deleted file mode 100644
index ae45397..0000000
--- a/.github/workflows/documentation.yaml
+++ /dev/null
@@ -1,63 +0,0 @@
-# DO NOT EDIT THIS FILE!
-#
-# It's auto-generated by sonata-project/dev-kit package.
-
-name: Documentation
-
-on:
-  push:
-    branches:
-      - master
-      - 2.x
-  pull_request:
-
-jobs:
-  build:
-    name: Sphinx build
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.7'
-
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-
-      - name: Install Sphinx dependencies
-        run: sudo apt-get install python-dev build-essential
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-
-          key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
-
-      - name: Install custom requirements via pip
-        run: pip install -r docs/requirements.txt
-
-      - name: Build documentation
-        run: make docs
-
-  doctor-rst:
-    name: DOCtor-RST
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Run DOCtor-RST
-        uses: docker://oskarstark/doctor-rst
-        with:
-          args: --short
-        env:
-          DOCS_DIR: 'docs/'
diff --git a/docs/.doctor-rst.yaml b/docs/.doctor-rst.yaml
deleted file mode 100644
index 3ee2e2b..0000000
--- a/docs/.doctor-rst.yaml
+++ /dev/null
@@ -1,38 +0,0 @@
-# DO NOT EDIT THIS FILE!
-#
-# It's auto-generated by sonata-project/dev-kit package.
-
-rules:
-    blank_line_after_directive: ~
-    short_array_syntax: ~
-    typo: ~
-    replacement: ~
-    composer_dev_option_at_the_end: ~
-    yarn_dev_option_at_the_end: ~
-    versionadded_directive_should_have_version: ~
-    no_composer_req: ~
-    no_php_open_tag_in_code_block_php_directive: ~
-    blank_line_after_filepath_in_code_block: ~
-    no_php_prefix_before_bin_console: ~
-    use_deprecated_directive_instead_of_versionadded: ~
-    no_space_before_self_xml_closing_tag: ~
-    no_explicit_use_of_code_block_php: ~
-    ensure_order_of_code_blocks_in_configuration_block: ~
-    american_english: ~
-    valid_use_statements: ~
-    extend_abstract_admin: ~
-    final_admin_class: ~
-    final_admin_extension_classes: ~
-    no_admin_yaml: ~
-    no_bash_prompt: ~
-    no_composer_phar: ~
-    no_inheritdoc: ~
-    yaml_instead_of_yml_suffix: ~
-    no_app_bundle: ~
-    no_config_yaml: ~
-    kernel_instead_of_app_kernel: ~
-    no_app_console: ~
-
-whitelist:
-    lines:
-        - '.. versionadded:: 2.x'
diff --git a/docs/conf.py b/docs/conf.py
deleted file mode 100644
index 860bd4c..0000000
--- a/docs/conf.py
+++ /dev/null
@@ -1,263 +0,0 @@
-# -*- coding: utf-8 -*-
-
-# DO NOT EDIT THIS FILE!
-#
-# It's auto-generated by sonata-project/dev-kit package.
-
-# IoC documentation build configuration file, created by
-# sphinx-quickstart on Fri Mar 29 01:43:00 2013.
-#
-# This file is execfile()d with the current directory set to its containing dir.
-#
-# Note that not all possible configuration values are present in this
-# autogenerated file.
-#
-# All configuration values have a default; values that are commented out
-# serve to show the default.
-
-import sys, os
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-
-# adding PhpLexer
-from sphinx.highlighting import lexers
-from pygments.lexers.web import PhpLexer
-
-# -- General configuration -----------------------------------------------------
-
-# If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode']
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
-
-# The suffix of source filenames.
-source_suffix = '.rst'
-
-# The encoding of source files.
-#source_encoding = 'utf-8-sig'
-
-# The master toctree document.
-master_doc = 'index'
-
-# General information about the project.
-project = u'SonataGoogleAuthenticator'
-copyright = u'2010-2020, Thomas Rabaix'
-
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-# The short X.Y version.
-#version = '0.0.1'
-# The full version, including alpha/beta/rc tags.
-#release = '0.0.1'
-
-# The language for content autogenerated by Sphinx. Refer to documentation
-# for a list of supported languages.
-#language = None
-
-# There are two options for replacing |today|: either, you set today to some
-# non-false value, then it is used:
-#today = ''
-# Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['_build']
-
-# The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
-
-# If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
-
-# If true, the current module name will be prepended to all description
-# unit titles (such as .. function::).
-#add_module_names = True
-
-# If true, sectionauthor and moduleauthor directives will be shown in the
-# output. They are ignored by default.
-#show_authors = False
-
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
-
-# This will be used when using the shorthand notation
-highlight_language = 'php'
-
-# A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
-
-# -- Settings for symfony doc extension ---------------------------------------------------
-
-# enable highlighting for PHP code not between ``<?php ... ?>`` by default
-lexers['php'] = PhpLexer(startinline=True)
-lexers['php-annotations'] = PhpLexer(startinline=True)
-lexers['php-standalone'] = PhpLexer(startinline=True)
-
-# -- Options for HTML output ---------------------------------------------------
-import sphinx_rtd_theme
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-#html_theme_options = {}
-
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-#html_title = None
-
-# A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
-
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-#html_logo = None
-
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-#html_favicon = None
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-
-# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
-# using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
-
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-#html_use_smartypants = True
-
-# Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
-
-# Additional templates that should be rendered to pages, maps page names to
-# template names.
-#html_additional_pages = {}
-
-# If false, no module index is generated.
-#html_domain_indices = True
-
-# If false, no index is generated.
-#html_use_index = True
-
-# If true, the index is split into individual pages for each letter.
-#html_split_index = False
-
-# If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
-
-# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
-
-# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
-
-# If true, an OpenSearch description file will be output, and all pages will
-# contain a <link> tag referring to it.  The value of this option must be the
-# base URL from which the finished HTML is served.
-#html_use_opensearch = ''
-
-# This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
-
-# Output file base name for HTML help builder.
-htmlhelp_basename = 'doc'
-
-
-# -- Options for LaTeX output --------------------------------------------------
-
-latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title, author, documentclass [howto/manual]).
-#latex_documents = [
-#  ('index', 'PythonElement.tex', u'Python Documentation',
-#   u'Thomas Rabaix', 'manual'),
-#]
-
-# The name of an image file (relative to this directory) to place at the top of
-# the title page.
-#latex_logo = None
-
-# For "manual" documents, if this is true, then toplevel headings are parts,
-# not chapters.
-#latex_use_parts = False
-
-# If true, show page references after internal links.
-#latex_show_pagerefs = False
-
-# If true, show URL addresses after external links.
-#latex_show_urls = False
-
-# Documents to append as an appendix to all manuals.
-#latex_appendices = []
-
-# If false, no module index is generated.
-#latex_domain_indices = True
-
-
-# -- Options for manual page output --------------------------------------------
-
-# One entry per manual page. List of tuples
-#(source start file, name, description, authors, manual section).
-#man_pages = [
-#    ('index', 'ioc', u'IoC Documentation',
-#     [u'Thomas Rabaix'], 1)
-#]
-
-# If true, show URL addresses after external links.
-#man_show_urls = False
-
-
-# -- Options for Texinfo output ------------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-#texinfo_documents = [
-#  ('index', 'IoC', u'IoC Documentation',
-#   u'Thomas Rabaix', 'IoC', 'One line description of project.',
-#   'Miscellaneous'),
-#]
-
-# Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
-
-# If false, no module index is generated.
-#texinfo_domain_indices = True
-
-# How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
-
-# Use PHP syntax highlighting in code examples by default
-highlight_language='php'
diff --git a/docs/requirements.txt b/docs/requirements.txt
deleted file mode 100644
index ee596d3..0000000
--- a/docs/requirements.txt
+++ /dev/null
@@ -1,7 +0,0 @@
-# DO NOT EDIT THIS FILE!
-#
-# It's auto-generated by sonata-project/dev-kit package.
-
-Sphinx==1.8.5
-git+https://github.com/fabpot/sphinx-php.git
-sphinx_rtd_theme
```