### PR TITLE
Move crons from Symfony Cloud to Github Actions

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,45 @@
+name: Auto merge
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  auto-merge:
+    name: Apply
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Add PHPUnit matcher
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Set Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Dispatch files
+        run: bin/console auto-merge --apply
+        env:
+          GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
+          DEK_KIT_TOKEN: ${{ secrets.DEV_KIT_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/dispatch-with-files.yaml
+++ b/.github/workflows/dispatch-with-files.yaml
@@ -1,0 +1,47 @@
+name: Dispatch with files
+
+on:
+  schedule:
+    - cron: '5 2 * * *'
+
+  workflow_dispatch:
+
+jobs:
+  dispatch-with-files:
+    name: Apply
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Add PHPUnit matcher
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Set Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Dispatch files
+        run: bin/console dispatch --with-files --apply
+        env:
+          GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
+          DEK_KIT_TOKEN: ${{ secrets.DEV_KIT_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -1,0 +1,47 @@
+name: Dispatch
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    name: Apply
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Add PHPUnit matcher
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Set Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Dispatch files
+        run: bin/console dispatch --apply
+        env:
+          GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
+          DEK_KIT_TOKEN: ${{ secrets.DEV_KIT_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/merge-conflicts.yaml
+++ b/.github/workflows/merge-conflicts.yaml
@@ -1,0 +1,45 @@
+name: Merge conflicts
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  merge-conflicts:
+    name: Apply
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Add PHPUnit matcher
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Set Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Dispatch files
+        run: bin/console merge-conflicts --apply
+        env:
+          GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
+          DEK_KIT_TOKEN: ${{ secrets.DEV_KIT_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/pull-request-auto-merge.yaml
+++ b/.github/workflows/pull-request-auto-merge.yaml
@@ -1,0 +1,45 @@
+name: Pull request auto merge
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+
+jobs:
+  pull-request-auto-merge:
+    name: Apply
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Add PHPUnit matcher
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Set Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Dispatch files
+        run: bin/console pull-request-auto-merge --apply
+        env:
+          GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
+          DEK_KIT_TOKEN: ${{ secrets.DEV_KIT_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.symfony.cloud.yaml
+++ b/.symfony.cloud.yaml
@@ -36,35 +36,3 @@ hooks:
         set -x -e
 
         (>&2 symfony-deploy)
-
-crons:
-    merge-conflicts:
-        spec: '*/10 * * * *'
-        cmd: |
-            if [ "$SYMFONY_BRANCH" = master ]; then
-                croncape bin/console merge-conflicts --apply
-            fi
-    pull-request-auto-merge:
-        spec: '*/5 * * * *'
-        cmd: |
-            if [ "$SYMFONY_BRANCH" = master ]; then
-                croncape bin/console pull-request-auto-merge --apply
-            fi
-    auto-merge:
-        spec: '0 2 * * *'
-        cmd: |
-            if [ "$SYMFONY_BRANCH" = master ]; then
-                croncape bin/console auto-merge --apply
-            fi
-    dispatch:
-        spec: '*/30 * * * *'
-        cmd: |
-            if [ "$SYMFONY_BRANCH" = master ]; then
-                croncape bin/console dispatch --apply
-            fi
-    dispatch-with-files:
-        spec: '5 2 * * *'
-        cmd: |
-            if [ "$SYMFONY_BRANCH" = master ]; then
-                croncape bin/console dispatch --with-files --apply
-            fi

--- a/src/Github/GithubHookProcessor.php
+++ b/src/Github/GithubHookProcessor.php
@@ -63,7 +63,7 @@ final class GithubHookProcessor
      */
     public function processReviewLabel(Event $event, array $payload): void
     {
-        if ($payload['action'] !== 'synchronize') {
+        if ('synchronize' !== $payload['action']) {
             return;
         }
 


### PR DESCRIPTION
Closes https://github.com/sonata-project/dev-kit/issues/820

Symfony Cloud will still be needed by only because of the webhook, and that does not need frequent deploys, because it only does a comment on pull request that need a rebase because have conflicts

Someone (@greg0ire or @OskarStark) will need to create the secrets on this repository settings