### PR TITLE
Fix: Payload

### DIFF
--- a/src/Github/Domain/Value/Webhook/Payload.php
+++ b/src/Github/Domain/Value/Webhook/Payload.php
@@ -24,15 +24,17 @@ final class Payload
     private string $action;
     private int $issueId;
     private int $issueAuthorId;
-    private int $commentAuthorId;
+    private ?int $commentAuthorId;
     private Repository $repository;
 
-    private function __construct(string $action, int $issueId, int $issueAuthorId, int $commentAuthorId, Repository $repository)
+    private function __construct(string $action, int $issueId, int $issueAuthorId, ?int $commentAuthorId, Repository $repository)
     {
         Assert::stringNotEmpty($action);
         Assert::greaterThan($issueId, 0);
         Assert::greaterThan($issueAuthorId, 0);
-        Assert::greaterThan($commentAuthorId, 0);
+        if (null !== $commentAuthorId) {
+            Assert::greaterThan($commentAuthorId, 0);
+        }
 
         $this->action = $action;
         $this->issueId = $issueId;
@@ -58,10 +60,12 @@ final class Payload
         Assert::keyExists($payload[$issueKey]['user'], 'id');
         $issueAuthorId = $payload[$issueKey]['user']['id'];
 
-        Assert::keyExists($payload, 'comment');
-        Assert::keyExists($payload['comment'], 'user');
-        Assert::keyExists($payload['comment']['user'], 'id');
-        $commentAuthorId = $payload['comment']['user']['id'];
+        $commentAuthorId = null;
+        if (\array_key_exists('comment', $payload)) {
+            Assert::keyExists($payload['comment'], 'user');
+            Assert::keyExists($payload['comment']['user'], 'id');
+            $commentAuthorId = $payload['comment']['user']['id'];
+        }
 
         Assert::keyExists($payload, 'repository');
         Assert::keyExists($payload['repository'], 'full_name');
@@ -96,11 +100,6 @@ final class Payload
     public function issueAuthorId(): int
     {
         return $this->issueAuthorId;
-    }
-
-    public function commentAuthorId(): int
-    {
-        return $this->commentAuthorId;
     }
 
     public function isTheCommentFromTheAuthor(): bool

--- a/tests/Github/Domain/Value/Webhook/PayloadTest.php
+++ b/tests/Github/Domain/Value/Webhook/PayloadTest.php
@@ -36,7 +36,7 @@ final class PayloadTest extends TestCase
             ],
             'comment' => [
                 'user' => [
-                    'id' => $commentAuthorId = 567,
+                    'id' => 567,
                 ],
             ],
             'repository' => [
@@ -51,7 +51,6 @@ final class PayloadTest extends TestCase
         self::assertSame($action, $payload->action());
         self::assertSame($issueId, $payload->issueId());
         self::assertSame($issueAuthorId, $payload->issueAuthorId());
-        self::assertSame($commentAuthorId, $payload->commentAuthorId());
         self::assertTrue($payload->isTheCommentFromTheAuthor());
         self::assertSame($repository, $payload->repository()->toString());
     }
@@ -73,7 +72,7 @@ final class PayloadTest extends TestCase
             ],
             'comment' => [
                 'user' => [
-                    'id' => $commentAuthorId = 456,
+                    'id' => 456,
                 ],
             ],
             'repository' => [
@@ -88,7 +87,6 @@ final class PayloadTest extends TestCase
         self::assertSame($action, $payload->action());
         self::assertSame($issueId, $payload->issueId());
         self::assertSame($issueAuthorId, $payload->issueAuthorId());
-        self::assertSame($commentAuthorId, $payload->commentAuthorId());
         self::assertTrue($payload->isTheCommentFromTheAuthor());
         self::assertSame($repository, $payload->repository()->toString());
     }
@@ -110,7 +108,7 @@ final class PayloadTest extends TestCase
             ],
             'comment' => [
                 'user' => [
-                    'id' => $commentAuthorId = 789,
+                    'id' => 789,
                 ],
             ],
             'repository' => [
@@ -125,7 +123,37 @@ final class PayloadTest extends TestCase
         self::assertSame($action, $payload->action());
         self::assertSame($issueId, $payload->issueId());
         self::assertSame($issueAuthorId, $payload->issueAuthorId());
-        self::assertSame($commentAuthorId, $payload->commentAuthorId());
+        self::assertFalse($payload->isTheCommentFromTheAuthor());
+        self::assertSame($repository, $payload->repository()->toString());
+    }
+
+    /**
+     * @test
+     */
+    public function thatCommentDoesNotNeedToBeSetInPayload(): void
+    {
+        $event = Event::fromString('issue_comment');
+
+        $array = [
+            'action' => $action = 'foo',
+            'issue' => [
+                'number' => $issueId = 123,
+                'user' => [
+                    'id' => $issueAuthorId = 456,
+                ],
+            ],
+            'repository' => [
+                'full_name' => $repository = 'sonata-project/SonataAdminBundle',
+            ],
+        ];
+
+        $json = json_encode($array);
+
+        $payload = Payload::fromJsonString($json, $event);
+
+        self::assertSame($action, $payload->action());
+        self::assertSame($issueId, $payload->issueId());
+        self::assertSame($issueAuthorId, $payload->issueAuthorId());
         self::assertFalse($payload->isTheCommentFromTheAuthor());
         self::assertSame($repository, $payload->repository()->toString());
     }


### PR DESCRIPTION
```shell
Message
Uncaught PHP Exception InvalidArgumentException: "Expected the key "comment" to exist." at /app/vendor/webmozart/assert/src/Assert.php line 2042
Level
CRITICAL
Exception
{
    "class": "InvalidArgumentException",
    "message": "Expected the key \"comment\" to exist.",
    "code": 0,
    "file": "/app/vendor/webmozart/assert/src/Assert.php:2042",
    "trace": [
        "/app/vendor/webmozart/assert/src/Assert.php:1665",
        "/app/src/Github/Domain/Value/Webhook/Payload.php:61",
        "/app/src/Github/Domain/Value/Webhook/Payload.php:82",
        "/app/src/Controller/GithubController.php:45",
        "/app/vendor/symfony/http-kernel/HttpKernel.php:158",
        "/app/vendor/symfony/http-kernel/HttpKernel.php:80",
        "/app/vendor/symfony/http-kernel/Kernel.php:201",
        "/app/public/index.php:36"
    ]
}
```