### PR TITLE
Enhancement: Use constant instead of string

### DIFF
--- a/config/packages/github_api.yaml
+++ b/config/packages/github_api.yaml
@@ -3,9 +3,7 @@ services:
         arguments:
             - '@Github\HttpClient\Builder'
         calls:
-            # use: !php/const \Github\Client::AUTH_HTTP_TOKEN instead of: 'http_token'
-            # when the yaml linter can deal with custom tags
-            - ['authenticate', ['%env(GITHUB_OAUTH_TOKEN)%', null, 'http_token']]
+            - ['authenticate', ['%env(GITHUB_OAUTH_TOKEN)%', null, !php/const \Github\Client::AUTH_HTTP_TOKEN]]
 
     Github\HttpClient\Builder:
         arguments:


### PR DESCRIPTION
Lets see if the YAML linter supports custom tags now....