### PR TITLE
Fix: Do not use deprecated auth method

### DIFF
--- a/config/packages/github_api.yaml
+++ b/config/packages/github_api.yaml
@@ -3,9 +3,9 @@ services:
         arguments:
             - '@Github\HttpClient\Builder'
         calls:
-            # use: !php/const \Github\Client::AUTH_HTTP_TOKEN instead of: 'http_token'
+            # use: !php/const \Github\Client::AUTH_ACCESS_TOKEN instead of: 'access_token_header'
             # when the yaml linter can deal with custom tags
-            - ['authenticate', ['%env(GITHUB_OAUTH_TOKEN)%', null, 'http_token']]
+            - ['authenticate', ['%env(GITHUB_OAUTH_TOKEN)%', null, 'access_token_header']]
 
     Github\HttpClient\Builder:
         arguments:


### PR DESCRIPTION
    /**
     * Constant for authentication method. Indicates the new login method with
     * with username and token via HTTP Authentication.
     *
     * @deprecated Use `Client::AUTH_ACCESS_TOKEN` instead.
     */
    const AUTH_HTTP_TOKEN = 'http_token';

    /**
     * Authenticate using a client_id/client_secret combination.
     */
    const AUTH_CLIENT_ID = 'client_id_header';

    /**
     * Authenticate using a GitHub access token.
     */
    const AUTH_ACCESS_TOKEN = 'access_token_header';