### PR TITLE
Fix: Return value

### DIFF
--- a/src/Command/AutoMergeCommand.php
+++ b/src/Command/AutoMergeCommand.php
@@ -102,13 +102,13 @@ final class AutoMergeCommand extends AbstractNeedApplyCommand
             }
 
             try {
-                $response = $this->repositories->merge(
+                $successful = $this->repositories->merge(
                     $repository,
                     $base,
                     $head
                 );
 
-                if (\is_array($response) && \array_key_exists('sha', $response)) {
+                if ($successful) {
                     $this->io->success(sprintf(
                         'Merged %s into %s',
                         $head,

--- a/src/Github/Api/Repositories.php
+++ b/src/Github/Api/Repositories.php
@@ -51,16 +51,22 @@ final class Repositories
         );
     }
 
-    public function merge(Repository $repository, string $base, string $head): ?array
+    public function merge(Repository $repository, string $base, string $head): bool
     {
         Assert::stringNotEmpty($base);
         Assert::stringNotEmpty($head);
 
-        return $this->github->repo()->merge(
+        $response = $this->github->repo()->merge(
             $repository->vendor(),
             $repository->name(),
             $base,
             $head
         );
+
+        if (\is_array($response) && \array_key_exists('sha', $response)) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
```json
{
    "class": "TypeError",
    "message": "Return value of App\\Github\\Api\\Repositories::merge() must be of the type array or null, string returned",
    "code": 0,
    "file": "/app/src/Github/Api/Repositories.php:60",
    "trace": [
        "/app/src/Command/AutoMergeCommand.php:106",
        "/app/src/Command/AutoMergeCommand.php:76",
        "/app/vendor/symfony/console/Command/Command.php:258",
        "/app/vendor/symfony/console/Application.php:934",
        "/app/vendor/symfony/framework-bundle/Console/Application.php:96",
        "/app/vendor/symfony/console/Application.php:264",
        "/app/vendor/symfony/framework-bundle/Console/Application.php:82",
        "/app/vendor/symfony/console/Application.php:140",
        "/app/bin/console:42"
    ]
}
```