### PR TITLE
Remove doctrine/mongodb-odm variant and mongodb compatibility layer

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -256,13 +256,11 @@ exporter:
             php: ['7.2', '7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
-                doctrine/mongodb-odm: ['1']
             services: [mongodb]
         2.x:
             php: ['7.2', '7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
-                doctrine/mongodb-odm: ['1']
             services: [mongodb]
 
 formatter-bundle:
@@ -320,7 +318,6 @@ media-bundle:
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']
-                doctrine/mongodb-odm: ['1']
                 sonata-project/admin-bundle: ['3']
                 imagine/imagine: ['0.7', '1']
         3.x:
@@ -328,7 +325,6 @@ media-bundle:
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']
-                doctrine/mongodb-odm: ['1']
                 sonata-project/admin-bundle: ['3']
                 imagine/imagine: ['0.7', '1']
 

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -86,11 +86,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
           restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
 {% endverbatim %}
-{% if 'mongodb' in services %}
-      - name: Install mongo compatibility layer
-        run: composer require alcaeus/mongo-php-adapter --no-update
 
-{% endif %}
       - name: Configuration required for PHP 8.0
         if: matrix.php-version == '8.0'
         run: composer config platform.php 7.4.99 && composer require phpunit/phpunit:"9.3.*" --no-update


### PR DESCRIPTION
Packages depending on doctrine/mongodb-odm require minimum of version 2.0,
so there is no need of this variant and alcaeus/mongo-php-adapter.

Ref: https://github.com/sonata-project/dev-kit/issues/1069