### PR TITLE
Use phpstan.neon.dist in the root directory instead of a specific .phpstan directory.

### DIFF
--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -29,8 +29,6 @@ jobs:
 {% if project.repository.name == 'SonataDoctrineMongoDBAdminBundle' %}
           CHECK_PLATFORM_REQUIREMENTS: false
 {% endif %}
-        with:
-          args: analyse -c .phpstan/phpstan.neon.dist
 {% endif %}
 {% if project.usesPsalm %}
   psalm:

--- a/templates/project/Makefile.twig
+++ b/templates/project/Makefile.twig
@@ -70,6 +70,6 @@ docs:
 {% if project.usesPHPStan %}
 
 phpstan:
-	docker run --env REQUIRE_DEV=true {% if project.repository.name == 'SonataDoctrineMongoDBAdminBundle' %}--env CHECK_PLATFORM_REQUIREMENTS=false {% endif %}--rm -it -w=/app -v ${PWD}:/app oskarstark/phpstan-ga:latest -c .phpstan/phpstan.neon.dist
+	docker run --env REQUIRE_DEV=true {% if project.repository.name == 'SonataDoctrineMongoDBAdminBundle' %}--env CHECK_PLATFORM_REQUIREMENTS=false {% endif %}--rm -it -w=/app -v ${PWD}:/app oskarstark/phpstan-ga:latest
 .PHONY: phpstan
 {% endif %}


### PR DESCRIPTION
Related to the discussion https://github.com/sonata-project/dev-kit/pull/1135#discussion_r498002243

SonataAdmin master does not use a specific folder
SonataDoctrineMongoDB does not use a specific folder (and test are failing now)

SonataAdmin 3.x use a specific folder
SonataDoctrineORM use a specific folder

Psalm does not use a specific folder

IMHO
- Phpstan and psalm should be consistent
- There is no need for a specific folder

So we should merge this, and move the `.phpstan/phpstan.neon.dist` in the rootDirectory on SonataAdmin 3.x and SonataDoctrine.