### PR TITLE
Add psalm to sonata-project/doctrine-mongodb-admin-bundle

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -190,6 +190,7 @@ doctrine-extensions:
 
 doctrine-mongodb-admin-bundle:
     phpstan: true
+    psalm: true
     custom_gitignore_part: |
         /tests/App/public/bundles
     excluded_files:


### PR DESCRIPTION
Ref: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/446

EDIT: looks like the mongodb extension should be installed, I'll take a look later today.