### PR TITLE
Use psalm in workflow without Github Action

### DIFF
--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -47,6 +47,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-version:
+          - "7.4"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -59,8 +64,28 @@ jobs:
           branch: master
 
 {% endif %}
-      - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
         with:
-          args: --shepherd
+            {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
+            coverage: none
+{% if branch.hasService('mongodb') %}
+            tools: composer:v{{ project.composerVersion }}, pecl
+            extensions: mongodb
+{% else %}
+            tools: composer:v{{ project.composerVersion }}
+{% endif %}
+      - name: Cache dependencies installed with composer
+        uses: actions/cache@v2
+        with:
+          path: ~/.composer/cache
+          {% verbatim %}key: ${{ matrix.php-version }}-composer-{% endverbatim %}
+          restore-keys: |
+            {% verbatim %}${{ matrix.php-version }}-composer-{% endverbatim %}
+
+      - name: Install dependencies with composer
+        run: "composer install --no-interaction --no-progress --no-suggest"
+
+      - name: Run a static analysis with Psalm
+        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --shepherd"
 {% endif %}


### PR DESCRIPTION
The https://github.com/psalm/psalm-github-actions we are using does not
allow to install php extensions or ignore platform requirements. We need
to be able to install mongodb extension for some packages.

This configuration is based on https://github.com/doctrine/orm/blob/5fde5801c152227ac7da00768633c9a06a779f5d/.github/workflows/ci.yml#L40

Ref: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/446 and https://github.com/sonata-project/sonata-doctrine-extensions/pull/252