### PR TITLE
Remove specific PHPUnit flow for php 8

### DIFF
--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -86,7 +86,12 @@ jobs:
 {% endverbatim %}
       - name: Configuration required for PHP 8.0
         if: matrix.php-version == '8.0'
-        run: composer config platform.php 7.4.99 && composer require phpunit/phpunit:"9.3.*" --no-update
+        run: composer config platform.php 7.4.99
+
+      - name: Sets phpunit 9 for PHP 8.0
+        if: matrix.php-version == '8.0'
+        run: |
+          echo 'SYMFONY_PHPUNIT_VERSION=9' >> $GITHUB_ENV
 
       - name: Install variant
         if: matrix.variant != 'normal'
@@ -107,12 +112,7 @@ jobs:
         run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable
 
       - name: Run Tests
-        if: matrix.php-version != '8.0'
         run: make test
-
-      - name: Run Tests (PHP 8.0)
-        if: matrix.php-version == '8.0'
-        run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
       - name: Send coverage to Codecov
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
This was previously done because prophecy was not compatible with php8. Now that it is compatible, the workflow wont stop at the install point of simple-phpunit execution. Simplify and unify workflow is good: POC: https://github.com/sonata-project/SonataMediaBundle/pull/1844