### PR TITLE
Stop using custom action for static analysis

### DIFF
--- a/templates/project/.github/workflows/documentation.yaml.twig
+++ b/templates/project/.github/workflows/documentation.yaml.twig
@@ -5,60 +5,60 @@
 name: Documentation
 
 on:
-  push:
-    branches:
+    push:
+        branches:
 {% for branch in project.branchesReverse %}
-      - {{ branch.name }}
+            - {{ branch.name }}
 {% endfor %}
-  pull_request:
+    pull_request:
 
 jobs:
-  build:
-    name: Sphinx build
+    build:
+        name: Sphinx build
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.7'
+            - name: Set up Python 3.7
+              uses: actions/setup-python@v1
+              with:
+                  python-version: '3.7'
 
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
+            - name: Display Python version
+              run: python -c "import sys; print(sys.version)"
 
-      - name: Install Sphinx dependencies
-        run: sudo apt-get install python-dev build-essential
+            - name: Install Sphinx dependencies
+              run: sudo apt-get install python-dev build-essential
 
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
+            - name: Cache pip
+              uses: actions/cache@v2
+              with:
+                  path: ~/.cache/pip
 {% verbatim %}
-          key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
+                  key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}
+                  restore-keys: ${{ runner.os }}-pip-
 {% endverbatim %}
-      - name: Install custom requirements via pip
-        run: pip install -r docs/requirements.txt
+            - name: Install custom requirements via pip
+              run: pip install -r docs/requirements.txt
 
-      - name: Build documentation
-        run: make docs
+            - name: Build documentation
+              run: make docs
 
-  doctor-rst:
-    name: DOCtor-RST
+    doctor-rst:
+        name: DOCtor-RST
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
-      - name: Run DOCtor-RST
-        uses: docker://oskarstark/doctor-rst
-        with:
-          args: --short --error-format=github
-        env:
-          DOCS_DIR: 'docs/'
+            - name: Run DOCtor-RST
+              uses: docker://oskarstark/doctor-rst
+              with:
+                  args: --short --error-format=github
+              env:
+                  DOCS_DIR: 'docs/'

--- a/templates/project/.github/workflows/lint.yaml.twig
+++ b/templates/project/.github/workflows/lint.yaml.twig
@@ -5,73 +5,73 @@
 name: Lint
 
 on:
-  push:
-    branches:
+    push:
+        branches:
 {% for branch in project.branchesReverse %}
-      - {{ branch.name }}
+            - {{ branch.name }}
 {% endfor %}
-  pull_request:
+    pull_request:
 
 jobs:
-  php-cs-fixer:
-    name: PHP-CS-Fixer
+    php-cs-fixer:
+        name: PHP-CS-Fixer
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
-      - name: Run PHP-CS-Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga:2.16.4
-        with:
-          args: --ansi --verbose --diff --dry-run
+            - name: Run PHP-CS-Fixer
+              uses: docker://oskarstark/php-cs-fixer-ga:2.16.4
+              with:
+                  args: --ansi --verbose --diff --dry-run
 
-  composer-normalize:
-    name: composer-normalize
+    composer-normalize:
+        name: composer-normalize
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
-      - name: Run composer-normalize
-        uses: docker://ergebnis/composer-normalize-action:0.8.0
-        with:
-          args: --dry-run
+            - name: Run composer-normalize
+              uses: docker://ergebnis/composer-normalize-action:0.8.0
+              with:
+                  args: --dry-run
 
-  yaml-files:
-    name: YAML files
+    yaml-files:
+        name: YAML files
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
-      - name: Install Ruby 2.6
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.6'
+            - name: Install Ruby 2.6
+              uses: actions/setup-ruby@v1
+              with:
+                  ruby-version: '2.6'
 
-      - name: Install required gem
-        run: gem install yaml-lint
+            - name: Install required gem
+              run: gem install yaml-lint
 
-      - name: Lint files
-        run: make lint-yaml
+            - name: Lint files
+              run: make lint-yaml
 
-  xml-files:
-    name: XML files
+    xml-files:
+        name: XML files
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
-      - name: Install required dependencies
-        run: sudo apt-get update && sudo apt-get install libxml2-utils
+            - name: Install required dependencies
+              run: sudo apt-get update && sudo apt-get install libxml2-utils
 
-      - name: Lint files
-        run: make lint-xml
+            - name: Lint files
+              run: make lint-xml

--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -15,19 +15,9 @@ on:
 jobs:
 {% if project.usesPHPStan %}
     phpstan:
-        {% verbatim %}name: PHPStan ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}{% endverbatim %}
+        name: PHPStan
 
         runs-on: ubuntu-latest
-
-        continue-on-error: ${{ matrix.allowed_to_fail }}
-
-        strategy:
-            matrix:
-                php-version:
-                    - '{{ branch.targetPhpVersion.toString }}'
-                dependencies: [highest]
-                allowed_to_fail: [false]
-                variant: [normal]
 
         steps:
             - name: Checkout
@@ -36,7 +26,7 @@ jobs:
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
-                  {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
+                  php-version: {{ branch.targetPhpVersion.toString }}
                   coverage: none
 {% if branch.hasService('mongodb') %}
                   tools: composer:v{{ project.composerVersion }}, pecl
@@ -52,15 +42,9 @@ jobs:
             - name: Cache Composer
               uses: actions/cache@v2
               with:
-{%- verbatim %}
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
-                  restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
-{% endverbatim %}
-
-            - name: Install variant
-              if: matrix.variant != 'normal'
-              {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
+                  path: {% verbatim %}${{ steps.composer-cache.outputs.dir }}{% endverbatim %}
+                  key: {% verbatim %}${{ runner.os }}{% endverbatim %}-{{ branch.targetPhpVersion.toString }}-composer-highest-normal
+                  restore-keys: {% verbatim %}${{ runner.os }}{% endverbatim %}-{{ branch.targetPhpVersion.toString }}-composer-
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}
@@ -70,12 +54,7 @@ jobs:
                   branch: master
 
 {% endif %}
-            - name: Install Composer dependencies (lowest)
-              if: matrix.dependencies == 'lowest'
-              run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable --prefer-lowest
-
             - name: Install Composer dependencies (highest)
-              if: matrix.dependencies == 'highest'
               run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable
 
             - name: PHPStan
@@ -84,19 +63,9 @@ jobs:
 {% endif %}
 {% if project.usesPsalm %}
     psalm:
-        {% verbatim %}name: Psalm ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}{% endverbatim %}
+        name: Psalm
 
         runs-on: ubuntu-latest
-
-        continue-on-error: ${{ matrix.allowed_to_fail }}
-
-        strategy:
-            matrix:
-                php-version:
-                    - '{{ branch.targetPhpVersion.toString }}'
-                dependencies: [highest]
-                allowed_to_fail: [false]
-                variant: [normal]
 
         steps:
             - name: Checkout code
@@ -105,7 +74,7 @@ jobs:
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
-                  {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
+                  php-version: {{ branch.targetPhpVersion.toString }}
                   coverage: none
 {% if branch.hasService('mongodb') %}
                   tools: composer:v{{ project.composerVersion }}, pecl
@@ -121,15 +90,9 @@ jobs:
             - name: Cache Composer
               uses: actions/cache@v2
               with:
-{%- verbatim %}
                   path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
-                  restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
-{% endverbatim %}
-
-            - name: Install variant
-              if: matrix.variant != 'normal'
-              {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
+                  key: ${{ runner.os }}-{{ branch.targetPhpVersion.toString }}-composer-highest-normal
+                  restore-keys: ${{ runner.os }}-{{ branch.targetPhpVersion.toString }}-composer-
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}
@@ -139,12 +102,7 @@ jobs:
                   branch: master
 
 {% endif %}
-            - name: Install Composer dependencies (lowest)
-              if: matrix.dependencies == 'lowest'
-              run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable --prefer-lowest
-
             - name: Install Composer dependencies (highest)
-              if: matrix.dependencies == 'highest'
               run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable
 
             - name: Psalm

--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -5,62 +5,62 @@
 name: Quality assurance
 
 on:
-  push:
-    branches:
+    push:
+        branches:
 {% for branch in project.branchesReverse %}
-      - {{ branch.name }}
+            - {{ branch.name }}
 {% endfor %}
-  pull_request:
+    pull_request:
 
 jobs:
 {% if project.usesPHPStan %}
-  phpstan:
-    name: PHPStan
+    phpstan:
+        name: PHPStan
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}
-      - name: Set COMPOSER_ROOT_VERSION environment variable
-        uses: ergebnis/composer-root-version-action@0.2.0
-        with:
-          branch: master
+            - name: Set COMPOSER_ROOT_VERSION environment variable
+              uses: ergebnis/composer-root-version-action@0.2.0
+              with:
+                  branch: master
 
 {% endif %}
-      - name: PHPStan
-        uses: docker://oskarstark/phpstan-ga
-        env:
-          REQUIRE_DEV: true
+            - name: PHPStan
+              uses: docker://oskarstark/phpstan-ga
+              env:
+                  REQUIRE_DEV: true
 {% if project.repository.name in ['SonataDoctrineMongoDBAdminBundle', 'sandbox'] %}
-          CHECK_PLATFORM_REQUIREMENTS: false
+                  CHECK_PLATFORM_REQUIREMENTS: false
 {% endif %}
-        with:
-          args: analyse
+              with:
+                  args: analyse
 {% endif %}
 {% if project.usesPsalm %}
-  psalm:
-    name: Psalm
+    psalm:
+        name: Psalm
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}
-      - name: Set COMPOSER_ROOT_VERSION environment variable
-        uses: ergebnis/composer-root-version-action@0.2.0
-        with:
-          branch: master
+            - name: Set COMPOSER_ROOT_VERSION environment variable
+              uses: ergebnis/composer-root-version-action@0.2.0
+              with:
+                  branch: master
 
 {% endif %}
-      - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
-        with:
-          args: --shepherd
+            - name: Psalm
+              uses: docker://vimeo/psalm-github-actions
+              with:
+                  args: --shepherd
 {% endif %}

--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -24,27 +24,10 @@ jobs:
         strategy:
             matrix:
                 php-version:
-{% for phpVersion in branch.phpVersions %}
-                    - '{{ phpVersion.toString }}'
-{% endfor %}
+                    - '{{ branch.targetPhpVersion.toString }}'
                 dependencies: [highest]
                 allowed_to_fail: [false]
                 variant: [normal]
-                include:
-                    - php-version: '{{ branch.lowestPhpVersion.toString }}'
-                      dependencies: lowest
-                      allowed_to_fail: false
-                      variant: normal
-                    - php-version: '8.0'
-                      dependencies: highest
-                      allowed_to_fail: true
-                      variant: normal
-{% for variant in branch.variants %}
-                    - php-version: '{{ branch.targetPhpVersion.toString }}'
-                      dependencies: highest
-                      allowed_to_fail: false
-                      variant: '{{ variant.toString|raw }}'
-{% endfor %}
 
         steps:
             - name: Checkout
@@ -110,27 +93,10 @@ jobs:
         strategy:
             matrix:
                 php-version:
-{% for phpVersion in branch.phpVersions %}
-                    - '{{ phpVersion.toString }}'
-{% endfor %}
+                    - '{{ branch.targetPhpVersion.toString }}'
                 dependencies: [highest]
                 allowed_to_fail: [false]
                 variant: [normal]
-                include:
-                    - php-version: '{{ branch.lowestPhpVersion.toString }}'
-                      dependencies: lowest
-                      allowed_to_fail: false
-                      variant: normal
-                    - php-version: '8.0'
-                      dependencies: highest
-                      allowed_to_fail: true
-                      variant: normal
-{% for variant in branch.variants %}
-                    - php-version: '{{ branch.targetPhpVersion.toString }}'
-                      dependencies: highest
-                      allowed_to_fail: false
-                      variant: '{{ variant.toString|raw }}'
-{% endfor %}
 
         steps:
             - name: Checkout code

--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -15,14 +15,70 @@ on:
 jobs:
 {% if project.usesPHPStan %}
     phpstan:
-        name: PHPStan
+        {% verbatim %}name: PHPStan ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}{% endverbatim %}
 
         runs-on: ubuntu-latest
+
+        continue-on-error: ${{ matrix.allowed_to_fail }}
+
+        strategy:
+            matrix:
+                php-version:
+{% for phpVersion in branch.phpVersions %}
+                    - '{{ phpVersion.toString }}'
+{% endfor %}
+                dependencies: [highest]
+                allowed_to_fail: [false]
+                variant: [normal]
+                include:
+                    - php-version: '{{ branch.lowestPhpVersion.toString }}'
+                      dependencies: lowest
+                      allowed_to_fail: false
+                      variant: normal
+                    - php-version: '8.0'
+                      dependencies: highest
+                      allowed_to_fail: true
+                      variant: normal
+{% for variant in branch.variants %}
+                    - php-version: '{{ branch.targetPhpVersion.toString }}'
+                      dependencies: highest
+                      allowed_to_fail: false
+                      variant: '{{ variant.toString|raw }}'
+{% endfor %}
 
         steps:
             - name: Checkout
               uses: actions/checkout@v2
 
+            - name: Install PHP with extensions
+              uses: shivammathur/setup-php@v2
+              with:
+                  {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
+                  coverage: none
+{% if branch.hasService('mongodb') %}
+                  tools: composer:v{{ project.composerVersion }}, pecl
+                  extensions: mongodb
+{% else %}
+                  tools: composer:v{{ project.composerVersion }}
+{% endif %}
+
+            - name: Set Composer cache directory
+              id: composer-cache
+              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            - name: Cache Composer
+              uses: actions/cache@v2
+              with:
+{%- verbatim %}
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
+                  restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
+{% endverbatim %}
+
+            - name: Install variant
+              if: matrix.variant != 'normal'
+              {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
+
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}
             - name: Set COMPOSER_ROOT_VERSION environment variable
@@ -31,26 +87,84 @@ jobs:
                   branch: master
 
 {% endif %}
+            - name: Install Composer dependencies (lowest)
+              if: matrix.dependencies == 'lowest'
+              run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable --prefer-lowest
+
+            - name: Install Composer dependencies (highest)
+              if: matrix.dependencies == 'highest'
+              run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable
+
             - name: PHPStan
-              uses: docker://oskarstark/phpstan-ga
-              env:
-                  REQUIRE_DEV: true
-{% if project.repository.name in ['SonataDoctrineMongoDBAdminBundle', 'sandbox'] %}
-                  CHECK_PLATFORM_REQUIREMENTS: false
-{% endif %}
-              with:
-                  args: analyse
+              run: vendor/bin/phpstan --memory-limit=1G analyse
+
 {% endif %}
 {% if project.usesPsalm %}
     psalm:
-        name: Psalm
+        {% verbatim %}name: Psalm ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}{% endverbatim %}
 
         runs-on: ubuntu-latest
+
+        continue-on-error: ${{ matrix.allowed_to_fail }}
+
+        strategy:
+            matrix:
+                php-version:
+{% for phpVersion in branch.phpVersions %}
+                    - '{{ phpVersion.toString }}'
+{% endfor %}
+                dependencies: [highest]
+                allowed_to_fail: [false]
+                variant: [normal]
+                include:
+                    - php-version: '{{ branch.lowestPhpVersion.toString }}'
+                      dependencies: lowest
+                      allowed_to_fail: false
+                      variant: normal
+                    - php-version: '8.0'
+                      dependencies: highest
+                      allowed_to_fail: true
+                      variant: normal
+{% for variant in branch.variants %}
+                    - php-version: '{{ branch.targetPhpVersion.toString }}'
+                      dependencies: highest
+                      allowed_to_fail: false
+                      variant: '{{ variant.toString|raw }}'
+{% endfor %}
 
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
 
+            - name: Install PHP with extensions
+              uses: shivammathur/setup-php@v2
+              with:
+                  {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
+                  coverage: none
+{% if branch.hasService('mongodb') %}
+                  tools: composer:v{{ project.composerVersion }}, pecl
+                  extensions: mongodb
+{% else %}
+                  tools: composer:v{{ project.composerVersion }}
+{% endif %}
+
+            - name: Set Composer cache directory
+              id: composer-cache
+              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            - name: Cache Composer
+              uses: actions/cache@v2
+              with:
+{%- verbatim %}
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
+                  restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
+{% endverbatim %}
+
+            - name: Install variant
+              if: matrix.variant != 'normal'
+              {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
+
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}
             - name: Set COMPOSER_ROOT_VERSION environment variable
@@ -59,8 +173,15 @@ jobs:
                   branch: master
 
 {% endif %}
+            - name: Install Composer dependencies (lowest)
+              if: matrix.dependencies == 'lowest'
+              run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable --prefer-lowest
+
+            - name: Install Composer dependencies (highest)
+              if: matrix.dependencies == 'highest'
+              run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable
+
             - name: Psalm
-              uses: docker://vimeo/psalm-github-actions
-              with:
-                  args: --shepherd
+              run: vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --shepherd
+
 {% endif %}

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -5,118 +5,118 @@
 name: Test
 
 on:
-  push:
-    branches:
+    push:
+        branches:
 {% for branch in project.branchesReverse %}
-      - {{ branch.name }}
+            - {{ branch.name }}
 {% endfor %}
-  pull_request:
+    pull_request:
 
 jobs:
-  test:
-    {% verbatim %}name: PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}{% endverbatim %}
+    test:
+        {% verbatim %}name: PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}{% endverbatim %}
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    {% verbatim %}continue-on-error: ${{ matrix.allowed_to_fail }}{% endverbatim %}
+        {% verbatim %}continue-on-error: ${{ matrix.allowed_to_fail }}{% endverbatim %}
 
 {% if branch.hasService('mongodb') %}
-    services:
-      mongo:
-        image: mongo
-        ports:
-          - 27017:27017
+        services:
+            mongo:
+                image: mongo
+                ports:
+                    - 27017:27017
 
 {% endif %}
-    strategy:
-      matrix:
-        php-version:
+        strategy:
+            matrix:
+                php-version:
 {% for phpVersion in branch.phpVersions %}
-          - '{{ phpVersion.toString }}'
+                    - '{{ phpVersion.toString }}'
 {% endfor %}
-        dependencies: [highest]
-        allowed_to_fail: [false]
-        variant: [normal]
-        include:
-          - php-version: '{{ branch.lowestPhpVersion.toString }}'
-            dependencies: lowest
-            allowed_to_fail: false
-            variant: normal
-          - php-version: '8.0'
-            dependencies: highest
-            allowed_to_fail: true
-            variant: normal
+                dependencies: [highest]
+                allowed_to_fail: [false]
+                variant: [normal]
+                include:
+                    - php-version: '{{ branch.lowestPhpVersion.toString }}'
+                      dependencies: lowest
+                      allowed_to_fail: false
+                      variant: normal
+                    - php-version: '8.0'
+                      dependencies: highest
+                      allowed_to_fail: true
+                      variant: normal
 {% for variant in branch.variants %}
-          - php-version: '{{ branch.targetPhpVersion.toString }}'
-            dependencies: highest
-            allowed_to_fail: false
-            variant: '{{ variant.toString|raw }}'
+                    - php-version: '{{ branch.targetPhpVersion.toString }}'
+                      dependencies: highest
+                      allowed_to_fail: false
+                      variant: '{{ variant.toString|raw }}'
 {% endfor %}
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
-      - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
-        with:
-          {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
-          coverage: pcov
+            - name: Install PHP with extensions
+              uses: shivammathur/setup-php@v2
+              with:
+                  {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
+                  coverage: pcov
 {% if branch.hasService('mongodb') %}
-          tools: composer:v{{ project.composerVersion }}, pecl
-          extensions: mongodb
+                  tools: composer:v{{ project.composerVersion }}, pecl
+                  extensions: mongodb
 {% else %}
-          tools: composer:v{{ project.composerVersion }}
+                  tools: composer:v{{ project.composerVersion }}
 {% endif %}
 
-      - name: Add PHPUnit matcher
-        {% verbatim %}run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"{% endverbatim %}
+            - name: Add PHPUnit matcher
+            {% verbatim %}run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"{% endverbatim %}
 
-      - name: Set Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+            - name: Set Composer cache directory
+              id: composer-cache
+              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - name: Cache Composer
-        uses: actions/cache@v2
-        with:
+            - name: Cache Composer
+              uses: actions/cache@v2
+              with:
 {%- verbatim %}
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
-          restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ matrix.variant }}
+                restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
 {% endverbatim %}
-      - name: Configuration required for PHP 8.0
-        if: matrix.php-version == '8.0'
-        run: composer config platform.php 7.4.99
+            - name: Configuration required for PHP 8.0
+              if: matrix.php-version == '8.0'
+              run: composer config platform.php 7.4.99
 
-      - name: Sets PHPUnit 9 for PHP 8.0
-        if: matrix.php-version == '8.0'
-        run: |
-          echo 'SYMFONY_PHPUNIT_VERSION=9' >> $GITHUB_ENV
+            - name: Sets PHPUnit 9 for PHP 8.0
+              if: matrix.php-version == '8.0'
+              run: |
+                  echo 'SYMFONY_PHPUNIT_VERSION=9' >> $GITHUB_ENV
 
-      - name: Install variant
-        if: matrix.variant != 'normal'
-        {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
+            - name: Install variant
+              if: matrix.variant != 'normal'
+            {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}
-      - name: Set COMPOSER_ROOT_VERSION environment variable
-        uses: ergebnis/composer-root-version-action@0.2.0
-        with:
-          branch: master
+            - name: Set COMPOSER_ROOT_VERSION environment variable
+              uses: ergebnis/composer-root-version-action@0.2.0
+              with:
+                  branch: master
 
 {% endif %}
-      - name: Install Composer dependencies (lowest)
-        if: matrix.dependencies == 'lowest'
-        run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable --prefer-lowest
+            - name: Install Composer dependencies (lowest)
+              if: matrix.dependencies == 'lowest'
+              run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable --prefer-lowest
 
-      - name: Install Composer dependencies (highest)
-        if: matrix.dependencies == 'highest'
-        run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable
+            - name: Install Composer dependencies (highest)
+              if: matrix.dependencies == 'highest'
+              run: composer update --prefer-dist --no-progress --no-interaction --prefer-stable
 
-      - name: Run Tests
-        run: make test
+            - name: Run Tests
+              run: make test
 
-      - name: Send coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          file: build/logs/clover.xml
+            - name: Send coverage to Codecov
+              uses: codecov/codecov-action@v1
+              with:
+                  file: build/logs/clover.xml


### PR DESCRIPTION
See the POC: https://github.com/sonata-project/SonataAdminBundle/pull/6549

Should we run static analysis on multiple PHP version, and lowest/highest dependency like I did ?
It's interesting, some of them are failing.

Or maybe just two build:
- Lowest PHP version, lowest dependencies.
- Highest PHP version, highest dependencies.