### PR TITLE
Drop php 7.2 builds

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -70,7 +70,7 @@ admin-bundle:
                 symfony/symfony: ['4.4']
                 sonata-project/block-bundle: ['4']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/block-bundle: ['3']
@@ -78,13 +78,13 @@ admin-bundle:
 admin-search-bundle:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
                 ruflin/elastica: ['5', '6']
         1.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -93,11 +93,11 @@ admin-search-bundle:
 article-bundle:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
         1.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
 
@@ -114,7 +114,7 @@ block-bundle:
             variants:
                 symfony/symfony: ['4.4', '5.1']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
 
@@ -123,13 +123,13 @@ classification-bundle:
         "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
             services: [mongodb]
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -138,18 +138,18 @@ classification-bundle:
 classification-media-bundle:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
 
 comment-bundle:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
 
@@ -159,7 +159,7 @@ dashboard-bundle:
         /node_modules
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -168,11 +168,11 @@ dashboard-bundle:
 datagrid-bundle:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
 
@@ -184,10 +184,10 @@ doctrine-extensions:
     has_documentation: false
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             services: [mongodb]
         1.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             services: [mongodb]
 
 doctrine-mongodb-admin-bundle:
@@ -200,13 +200,13 @@ doctrine-mongodb-admin-bundle:
         - tests/bootstrap.php.twig
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']
@@ -222,7 +222,7 @@ doctrine-orm-admin-bundle:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['dev-master']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -236,13 +236,13 @@ doctrine-phpcr-admin-bundle:
         - phpunit.xml.dist.twig
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
                 sonata-project/block-bundle: ['3']
         2.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -253,11 +253,11 @@ ecommerce:
         "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
 
@@ -266,12 +266,12 @@ exporter:
         - README.md.twig
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
             services: [mongodb]
         2.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
             services: [mongodb]
@@ -279,12 +279,12 @@ exporter:
 formatter-bundle:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/block-bundle: ['3']
         4.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/block-bundle: ['3']
@@ -292,11 +292,11 @@ formatter-bundle:
 form-extensions:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4', '5.1']
         1.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4', '5.1']
 
@@ -306,18 +306,18 @@ google-authenticator:
     has_documentation: false
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
         2.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
 
 intl-bundle:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4', '5.1']
         2.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4', '5.1']
                 sonata-project/user-bundle: ['4']
@@ -327,14 +327,14 @@ media-bundle:
         "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
                 imagine/imagine: ['0.7', '1']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']
@@ -346,12 +346,12 @@ news-bundle:
         "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -361,11 +361,11 @@ notification-bundle:
         "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
 
@@ -374,13 +374,13 @@ page-bundle:
         "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
                 sonata-project/block-bundle: ['3']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -406,7 +406,7 @@ seo-bundle:
             variants:
                 symfony/symfony: ['4.4', '5.1']
         2.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/block-bundle: ['3']
@@ -415,13 +415,13 @@ seo-bundle:
 timeline-bundle:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
                 sonata-project/block-bundle: ['3']
         3.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -437,7 +437,7 @@ translation-bundle:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['dev-master']
         2.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -445,11 +445,11 @@ translation-bundle:
 twig-extensions:
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4', '5.1']
         1.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4', '5.1']
 
@@ -458,13 +458,13 @@ user-bundle:
         "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"
     branches:
         master:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 friendsofsymfony/user-bundle: ['2']
                 sonata-project/admin-bundle: ['3']
         4.x:
-            php: ['7.2', '7.3', '7.4']
+            php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 friendsofsymfony/user-bundle: ['2']


### PR DESCRIPTION
Without a psalm bump, dev-kit PR are failing
See https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1183

There is multiple way to fix this
- Bumping psalm on Master only
- Require-dev php-parser version >= 4.4

But for simplicity I was thinking that since php 7.2 EOL is in 27 days, we could
- Remove 7.2 tests 
- Bump the php version to 7.3 in composer.json of 3.x branch
- Bump psalm to the next major version of 3.x branch

WDYT @sonata-project/contributors ?