### PR TITLE
Exclude tests/bootstrap.php instead of phpunit config for PHPCR

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -233,7 +233,7 @@ doctrine-phpcr-admin-bundle:
     custom_doctor_rst_whitelist_part:
         "    - '.. _`cmf-sandbox configuration`: https://github.com/symfony-cmf/cmf-sandbox/blob/master/app/config/config.yml'"
     excluded_files:
-        - phpunit.xml.dist.twig
+        - tests/bootstrap.php.twig
     branches:
         master:
             php: ['7.3', '7.4']


### PR DESCRIPTION
Related to https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/641