### PR TITLE
Ignore phpunit.xml.dist file again for phpcr

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -234,6 +234,7 @@ doctrine-phpcr-admin-bundle:
         "    - '.. _`cmf-sandbox configuration`: https://github.com/symfony-cmf/cmf-sandbox/blob/master/app/config/config.yml'"
     excluded_files:
         - tests/bootstrap.php.twig
+        - phpunit.xml.dist.twig
     branches:
         master:
             php: ['7.3', '7.4']


### PR DESCRIPTION
I need to add
```
<env name="KERNEL_CLASS" value="Sonata\DoctrinePHPCRAdminBundle\Tests\Fixtures\App\Kernel" />
```
and to use phpunit 8.5 for working tests.

I find a way to avoid the env variable (by overriding the kernel class in the tests) but I have an error 
```
Doctrine\Persistence\Mapping\MappingException: The class 'Sonata\DoctrinePHPCRAdminBundle\Tests\Fixtures\App\Document\Content' was not found in the chain configured namespaces Doctrine\ODM\PHPCR\Document
```
when I use phpunit 9.4

I don't know why and since the package is abandoned, I don't want to spend more time.
I just want to stop having a failing build for dev-kit update.
