### PR TITLE
Remove code that references php 7.2

### DIFF
--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -81,14 +81,6 @@ jobs:
             - name: Configuration required for PHP 8.0
               if: matrix.php-version == '8.0'
               run: composer config platform.php 7.4.99
-{% endif %}
-
-{# Remove when all branches drop support for php 7.2 #}
-{% if '7.2' == branch.lowestPhpVersion.toString %}
-            - name: Sets PHPUnit 8.5 for PHP 7.2
-              if: matrix.php-version == '7.2'
-              run: |
-                  echo 'SYMFONY_PHPUNIT_VERSION=8.5' >> $GITHUB_ENV
 
 {% endif %}
             - name: Install variant


### PR DESCRIPTION
I left a blank line https://github.com/sonata-project/SonataIntlBundle/blob/5f404980fffd5332eb71aea7729afd0aec8f330e/.github/workflows/test.yaml#L60-L64

Apparently [all branches have a minimum of PHP 7.3](https://github.com/sonata-project/dev-kit/blob/4cf3b3baaabd0d2bd835549bc2187b090807dbc4/config/projects.yaml), so this code can be removed and hopefully the blank line.