### PR TITLE
Use PHP 7.4 for target php in sonata-project/intl-bundle

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -315,10 +315,12 @@ intl-bundle:
     branches:
         master:
             php: ['7.3', '7.4', '8.0']
+            target_php: '7.4'
             variants:
                 symfony/symfony: ['4.4', '5.1']
         2.x:
             php: ['7.3', '7.4', '8.0']
+            target_php: '7.4'
             variants:
                 symfony/symfony: ['4.4', '5.1']
                 sonata-project/user-bundle: ['4']


### PR DESCRIPTION
sonata-project/user-bundle is not compatible with PHP 8.

@OskarStark not sure about this but I think that setting `target_php` would be the PHP version to use in variants, is that right?