### PR TITLE
Fix: GithubActions

### DIFF
--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -12,6 +12,9 @@ on:
 {% endfor %}
     pull_request:
 
+env:
+    ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
 jobs:
 {% if project.usesPHPStan %}
     phpstan:


### PR DESCRIPTION
![CleanShot 2020-12-04 at 10 24 12](https://user-images.githubusercontent.com/995707/101146156-f573f900-361a-11eb-8e82-05f2a06bb77e.png)

Reference: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/