### PR TITLE
Force Psalm to execute using target php version

### DIFF
--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -92,5 +92,5 @@ jobs:
                   composer-options: "--prefer-dist --prefer-stable"
 
             - name: Psalm
-              run: vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --shepherd
+              run: vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --shepherd --php-version={{ branch.targetPhpVersion.toString }}
 {% endif %}


### PR DESCRIPTION
POC: https://github.com/sonata-project/sonata-doctrine-extensions/pull/281

Right now we have `^7.3` as minimum PHP version, but we may use some packages that have its PHP dependency as: `^7.4` and use 7.4+ syntax. This makes Psalm fail as it infers the PHP Version from our composer (`7.3`) resulting in errors: https://github.com/sonata-project/sonata-doctrine-extensions/runs/1639286850


Ref: https://github.com/laminas/laminas-code/issues/67