### PR TITLE
Add cache-bundle

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -131,13 +131,11 @@ cache:
 cache-bundle:
   branches:
     master:
-      php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
+      php: ['7.3', '7.4']
       versions:
         symfony: ['4.4']
     3.x:
-      php: ['7.2', '7.3', '7.4']
-      target_php: '7.3'
+      php: ['7.3', '7.4']
       versions:
         symfony: ['4.4']
 

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -128,6 +128,19 @@ cache:
     2.x:
       php: ['7.3', '7.4', '8.0']
 
+cache-bundle:
+  branches:
+    master:
+      php: ['7.2', '7.3', '7.4']
+      target_php: '7.3'
+      versions:
+        symfony: ['4.4']
+    3.x:
+      php: ['7.2', '7.3', '7.4']
+      target_php: '7.3'
+      versions:
+        symfony: ['4.4']
+
 classification-bundle:
     custom_doctor_rst_whitelist_part:
         "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"


### PR DESCRIPTION
We should keep the CI currently, since this deprecated is still used by other sonata-projects.

https://github.com/sonata-project/cache/issues/49#issuecomment-754548244