### PR TITLE
Add apcu for cache repository

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -125,8 +125,10 @@ cache:
     branches:
         master:
             php: ['7.3', '7.4']
+            services: [apcu]
         2.x:
             php: ['7.3', '7.4']
+            services: [apcu]
 
 cache-bundle:
     branches:
@@ -134,10 +136,12 @@ cache-bundle:
             php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
+            services: [apcu]
         3.x:
             php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
+            services: [apcu]
 
 classification-bundle:
     custom_doctor_rst_whitelist_part:
@@ -148,13 +152,13 @@ classification-bundle:
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
         3.x:
             php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
 
 classification-media-bundle:
     branches:
@@ -206,10 +210,10 @@ doctrine-extensions:
     branches:
         master:
             php: ['7.3', '7.4']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
         1.x:
             php: ['7.3', '7.4']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
 
 doctrine-mongodb-admin-bundle:
     phpstan: true
@@ -218,13 +222,13 @@ doctrine-mongodb-admin-bundle:
     branches:
         master:
             php: ['7.3', '7.4']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['dev-master']
         3.x:
             php: ['7.3', '7.4']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -288,12 +292,12 @@ exporter:
             php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
         2.x:
             php: ['7.3', '7.4']
             variants:
                 symfony/symfony: ['4.4']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
 
 formatter-bundle:
     branches:
@@ -349,14 +353,14 @@ media-bundle:
     branches:
         master:
             php: ['7.3', '7.4']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
                 imagine/imagine: ['0.7', '1']
         3.x:
             php: ['7.3', '7.4']
-            services: [mongodb]
+            services: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -71,6 +71,8 @@ jobs:
 {% if branch.services|length > 0 %}
                   tools: composer:v{{ project.composerVersion }}, pecl
                   extensions: {{ branch.services|split(', ') }}
+              env:
+                  fail-fast: true
 {% else %}
                   tools: composer:v{{ project.composerVersion }}
 {% endif %}

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -68,10 +68,9 @@ jobs:
               with:
                   {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
                   coverage: pcov
-{% if branch.hasService('mongodb') %}
+{% if branch.services|length > 0 %}
                   tools: composer:v{{ project.composerVersion }}, pecl
-{# Change mongodb extension version to a stable one when available #}
-                  extensions: mongodb-1.9.0
+                  extensions: {{ branch.services|split(', ') }}
 {% else %}
                   tools: composer:v{{ project.composerVersion }}
 {% endif %}


### PR DESCRIPTION
I think the `ext-apcu` extension is needed for the cache library and the cache-bundle one.

I'm trying to add it.