### PR TITLE
Install webdrivers when using panther

### DIFF
--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -98,12 +98,22 @@ jobs:
                   branch: master
 
 {% endif %}
+{% if project.usesPanther %}
+            - name: Install browser drivers
+              run: composer require dbrekelmans/bdi:^0.3 --no-update --dev
+
+{% endif %}
             - name: "Install Composer dependencies ({% verbatim %}${{ matrix.dependencies }}{% endverbatim %})"
               uses: "ramsey/composer-install@v1"
               with:
                   dependency-versions: "{% verbatim %}${{ matrix.dependencies }}{% endverbatim %}"
                   composer-options: "--prefer-dist --prefer-stable"
 
+{% if project.usesPanther %}
+            - name: Download WebDriver drivers
+              run: vendor/bin/bdi detect drivers
+
+{% endif %}
             - name: Run Tests
               run: make test
 


### PR DESCRIPTION
See https://github.com/symfony/panther/blob/19c317132b078d243b69b08aafc466d7b6326826/README.md#installing-chromedriver-and-geckodriver

POC: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/512

We have to bump `symfony/panther` to `0.9`, but that can be done in the `dev-kit` PR.