### PR TITLE
Add drivers folder to gitignore if panther is used

### DIFF
--- a/templates/project/.gitignore.twig
+++ b/templates/project/.gitignore.twig
@@ -14,6 +14,7 @@ phpstan.neon
 /docs/_build/
 {% endif %}
 {% if project.usesPanther %}
+/drivers
 /tests/App/public/bundles
 {% endif %}
 {% if project.customGitignorePart is not empty %}


### PR DESCRIPTION
Since the version `0.9` of panther 
```
composer require --dev dbrekelmans/bdi
vendor/bin/bdi detect drivers
```
is required

We need to ignore the folder `drivers` then.

Any idea how to run `vendor/bin/bdi detect drivers` automatically too ?