### PR TITLE
Add support for another vendor name

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -285,6 +285,7 @@ ecommerce:
                 symfony/symfony: ['4.4']
 
 entity-audit-bundle:
+    vendor_name: simplethings
     excluded_files:
         - LICENSE
         - README.md

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -23,7 +23,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 abstract class AbstractCommand extends Command
 {
-    public const GITHUB_GROUP = 'sonata-project';
     public const GITHUB_USER = 'SonataCI';
     public const GITHUB_EMAIL = 'thomas+ci@sonata-project.org';
     public const SONATA_CI_BOT = 'SonataCI';

--- a/src/Config/Projects.php
+++ b/src/Config/Projects.php
@@ -43,7 +43,8 @@ final class Projects
 
         foreach ($projectsConfigs['projects'] as $name => $config) {
             $package = $this->packagist->get(sprintf(
-                'sonata-project/%s',
+                '%s/%s',
+                $config['vendor_name'],
                 $name
             ));
 

--- a/src/Config/ProjectsConfiguration.php
+++ b/src/Config/ProjectsConfiguration.php
@@ -34,6 +34,7 @@ class ProjectsConfiguration implements ConfigurationInterface
                     ->normalizeKeys(false)
                     ->prototype('array')
                         ->children()
+                            ->scalarNode('vendor_name')->defaultValue('sonata-project')->end()
                             ->scalarNode('composer_version')->defaultValue('2')->end()
                             ->booleanNode('panther')->defaultFalse()->end()
                             ->booleanNode('phpstan')->defaultFalse()->end()


### PR DESCRIPTION
The entityAuditBundle is under the simplethings vendor name, so I added support for this situation. @OskarStark 