### PR TITLE
Do not exclude fixtures from linter

### DIFF
--- a/templates/project/.php_cs.dist
+++ b/templates/project/.php_cs.dist
@@ -62,8 +62,6 @@ $rules = [
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
-    ->exclude('Tests/Fixtures')
-    ->exclude('tests/Fixtures')
     ->exclude('Resources/skeleton')
     ->exclude('Resources/public/vendor')
 ;


### PR DESCRIPTION
Let's try to not exclude the fixtures from the linter.
I don't know why it was excluded, but it should possible to lint them too.