### PR TITLE
Ignore `var` directory by php-cs-fixer

### DIFF
--- a/templates/project/.php_cs.dist
+++ b/templates/project/.php_cs.dist
@@ -64,6 +64,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude('Resources/skeleton')
     ->exclude('Resources/public/vendor')
+    ->exclude('var')
 ;
 
 return PhpCsFixer\Config::create()


### PR DESCRIPTION
Closes #883 