### PR TITLE
Add php extensions

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -364,6 +364,7 @@ media-bundle:
     branches:
         master:
             php: ['7.3', '7.4']
+            php_extensions: [soap, gd]
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']
@@ -371,6 +372,7 @@ media-bundle:
                 imagine/imagine: ['0.7', '1']
         3.x:
             php: ['7.3', '7.4']
+            php_extensions: [soap, gd]
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -149,14 +149,14 @@ classification-bundle:
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
         3.x:
             php: ['7.3', '7.4']
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
 
 classification-media-bundle:
     branches:
@@ -209,12 +209,12 @@ doctrine-extensions:
         master:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
             target_php: '7.4'
         1.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
             target_php: '7.4'
 
 doctrine-mongodb-admin-bundle:
@@ -225,7 +225,7 @@ doctrine-mongodb-admin-bundle:
         master:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
             target_php: '7.4'
             variants:
                 symfony/symfony: ['4.4']
@@ -233,7 +233,7 @@ doctrine-mongodb-admin-bundle:
         3.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
             target_php: '7.4'
             variants:
                 symfony/symfony: ['4.4']
@@ -310,13 +310,13 @@ exporter:
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4', '5.2']
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
         2.x:
             php: ['7.3', '7.4']
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4', '5.2']
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
 
 formatter-bundle:
     branches:
@@ -373,7 +373,7 @@ media-bundle:
         master:
             php: ['7.3', '7.4']
             php_extensions: [mangodb-1.9.0, soap, gd]
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -381,7 +381,7 @@ media-bundle:
         3.x:
             php: ['7.3', '7.4']
             php_extensions: [mango-1.9.0, soap, gd]
-            services: [mongodb, pecl]
+            tools: [mongodb, pecl]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -145,12 +145,14 @@ classification-bundle:
     branches:
         master:
             php: ['7.3', '7.4']
+            php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
             services: [mongodb]
         3.x:
             php: ['7.3', '7.4']
+            php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -206,10 +208,12 @@ doctrine-extensions:
     branches:
         master:
             php: ['7.3', '7.4', '8.0']
+            php_extensions: [mongodb-1.9.0]
             services: [mongodb]
             target_php: '7.4'
         1.x:
             php: ['7.3', '7.4', '8.0']
+            php_extensions: [mongodb-1.9.0]
             services: [mongodb]
             target_php: '7.4'
 
@@ -220,6 +224,7 @@ doctrine-mongodb-admin-bundle:
     branches:
         master:
             php: ['7.3', '7.4', '8.0']
+            php_extensions: [mongodb-1.9.0]
             services: [mongodb]
             target_php: '7.4'
             variants:
@@ -227,6 +232,7 @@ doctrine-mongodb-admin-bundle:
                 sonata-project/admin-bundle: ['dev-master']
         3.x:
             php: ['7.3', '7.4', '8.0']
+            php_extensions: [mongodb-1.9.0]
             services: [mongodb]
             target_php: '7.4'
             variants:
@@ -301,11 +307,13 @@ exporter:
     branches:
         master:
             php: ['7.3', '7.4']
+            php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4', '5.2']
             services: [mongodb]
         2.x:
             php: ['7.3', '7.4']
+            php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4', '5.2']
             services: [mongodb]
@@ -364,7 +372,7 @@ media-bundle:
     branches:
         master:
             php: ['7.3', '7.4']
-            php_extensions: [soap, gd]
+            php_extensions: [mangodb-1.9.0, soap, gd]
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']
@@ -372,7 +380,7 @@ media-bundle:
                 imagine/imagine: ['0.7', '1']
         3.x:
             php: ['7.3', '7.4']
-            php_extensions: [soap, gd]
+            php_extensions: [mango-1.9.0, soap, gd]
             services: [mongodb]
             variants:
                 symfony/symfony: ['4.4']

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -149,14 +149,14 @@ classification-bundle:
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
-            services: [mongodb]
+            services: [mongodb, pecl]
         3.x:
             php: ['7.3', '7.4']
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
-            services: [mongodb]
+            services: [mongodb, pecl]
 
 classification-media-bundle:
     branches:
@@ -209,12 +209,12 @@ doctrine-extensions:
         master:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            services: [mongodb]
+            services: [mongodb, pecl]
             target_php: '7.4'
         1.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            services: [mongodb]
+            services: [mongodb, pecl]
             target_php: '7.4'
 
 doctrine-mongodb-admin-bundle:
@@ -225,7 +225,7 @@ doctrine-mongodb-admin-bundle:
         master:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            services: [mongodb]
+            services: [mongodb, pecl]
             target_php: '7.4'
             variants:
                 symfony/symfony: ['4.4']
@@ -233,7 +233,7 @@ doctrine-mongodb-admin-bundle:
         3.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            services: [mongodb]
+            services: [mongodb, pecl]
             target_php: '7.4'
             variants:
                 symfony/symfony: ['4.4']
@@ -310,13 +310,13 @@ exporter:
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4', '5.2']
-            services: [mongodb]
+            services: [mongodb, pecl]
         2.x:
             php: ['7.3', '7.4']
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4', '5.2']
-            services: [mongodb]
+            services: [mongodb, pecl]
 
 formatter-bundle:
     branches:
@@ -373,7 +373,7 @@ media-bundle:
         master:
             php: ['7.3', '7.4']
             php_extensions: [mangodb-1.9.0, soap, gd]
-            services: [mongodb]
+            services: [mongodb, pecl]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -381,7 +381,7 @@ media-bundle:
         3.x:
             php: ['7.3', '7.4']
             php_extensions: [mango-1.9.0, soap, gd]
-            services: [mongodb]
+            services: [mongodb, pecl]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -149,14 +149,14 @@ classification-bundle:
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
-            tools: [mongodb, pecl]
+            tools: [pecl]
         3.x:
             php: ['7.3', '7.4']
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
-            tools: [mongodb, pecl]
+            tools: [pecl]
 
 classification-media-bundle:
     branches:
@@ -209,12 +209,12 @@ doctrine-extensions:
         master:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            tools: [mongodb, pecl]
+            tools: [pecl]
             target_php: '7.4'
         1.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            tools: [mongodb, pecl]
+            tools: [pecl]
             target_php: '7.4'
 
 doctrine-mongodb-admin-bundle:
@@ -225,7 +225,7 @@ doctrine-mongodb-admin-bundle:
         master:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            tools: [mongodb, pecl]
+            tools: [pecl]
             target_php: '7.4'
             variants:
                 symfony/symfony: ['4.4']
@@ -233,7 +233,7 @@ doctrine-mongodb-admin-bundle:
         3.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: [mongodb-1.9.0]
-            tools: [mongodb, pecl]
+            tools: [pecl]
             target_php: '7.4'
             variants:
                 symfony/symfony: ['4.4']
@@ -310,13 +310,13 @@ exporter:
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4', '5.2']
-            tools: [mongodb, pecl]
+            tools: [pecl]
         2.x:
             php: ['7.3', '7.4']
             php_extensions: [mongodb-1.9.0]
             variants:
                 symfony/symfony: ['4.4', '5.2']
-            tools: [mongodb, pecl]
+            tools: [pecl]
 
 formatter-bundle:
     branches:
@@ -373,7 +373,7 @@ media-bundle:
         master:
             php: ['7.3', '7.4']
             php_extensions: [mangodb-1.9.0, soap, gd]
-            tools: [mongodb, pecl]
+            tools: [pecl]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']
@@ -381,7 +381,7 @@ media-bundle:
         3.x:
             php: ['7.3', '7.4']
             php_extensions: [mango-1.9.0, soap, gd]
-            tools: [mongodb, pecl]
+            tools: [pecl]
             variants:
                 symfony/symfony: ['4.4']
                 sonata-project/admin-bundle: ['3']

--- a/src/Config/ProjectsConfiguration.php
+++ b/src/Config/ProjectsConfiguration.php
@@ -49,7 +49,7 @@ class ProjectsConfiguration implements ConfigurationInterface
                                 ->prototype('array')
                                     ->children()
                                         ->arrayNode('php')->prototype('scalar')->defaultValue([])->end()->end()
-                                        ->arrayNode('services')->prototype('scalar')->defaultValue([])->end()->end()
+                                        ->arrayNode('tools')->prototype('scalar')->defaultValue([])->end()->end()
                                         ->scalarNode('target_php')->defaultNull()->end()
                                         ->arrayNode('variants')
                                             ->normalizeKeys(false)

--- a/src/Domain/Value/Branch.php
+++ b/src/Domain/Value/Branch.php
@@ -77,10 +77,9 @@ final class Branch
             $phpVersions[$version] = PhpVersion::fromString($version);
         }
 
-        $tools = [];
-        foreach ($config['tools'] as $toolName) {
-            $tools[] = Tool::fromString($toolName);
-        }
+        $tools = array_map(static function (string $toolName): string {
+            return Tool::fromString($toolName);
+        }, $config['tools']);
 
         $variants = [];
         foreach ($config['variants'] as $variant => $versions) {

--- a/src/Domain/Value/Branch.php
+++ b/src/Domain/Value/Branch.php
@@ -96,8 +96,8 @@ final class Branch
         return new self(
             $name,
             $phpVersions,
-            $config['php_extensions'],
             $services,
+            $config['php_extensions'] ?? [],
             $variants,
             Path::fromString($config['docs_path']),
             Path::fromString($config['tests_path']),

--- a/src/Domain/Value/Branch.php
+++ b/src/Domain/Value/Branch.php
@@ -77,7 +77,7 @@ final class Branch
             $phpVersions[$version] = PhpVersion::fromString($version);
         }
 
-        $tools = array_map(static function (string $toolName): string {
+        $tools = array_map(static function (string $toolName): Tool {
             return Tool::fromString($toolName);
         }, $config['tools']);
 

--- a/src/Domain/Value/Branch.php
+++ b/src/Domain/Value/Branch.php
@@ -31,9 +31,9 @@ final class Branch
     private array $phpExtensions;
 
     /**
-     * @var Service[]
+     * @var Tool[]
      */
-    private array $services;
+    private array $tools;
 
     /**
      * @var Variant[]
@@ -46,13 +46,14 @@ final class Branch
 
     /**
      * @param array<string, PhpVersion> $phpVersions
-     * @param Service[]                 $services
+     * @param Tool[]                    $tools
+     * @param string[]                  $phpExtensions
      * @param Variant[]                 $variants
      */
     private function __construct(
         string $name,
         array $phpVersions,
-        array $services,
+        array $tools,
         array $phpExtensions,
         array $variants,
         Path $docsPath,
@@ -61,7 +62,7 @@ final class Branch
     ) {
         $this->name = TrimmedNonEmptyString::fromString($name)->toString();
         $this->phpVersions = $phpVersions;
-        $this->services = $services;
+        $this->tools = $tools;
         $this->phpExtensions = $phpExtensions;
         $this->variants = $variants;
         $this->docsPath = $docsPath;
@@ -76,9 +77,9 @@ final class Branch
             $phpVersions[$version] = PhpVersion::fromString($version);
         }
 
-        $services = [];
-        foreach ($config['services'] as $serviceName) {
-            $services[] = Service::fromString($serviceName);
+        $tools = [];
+        foreach ($config['tools'] as $toolName) {
+            $tools[] = Tool::fromString($toolName);
         }
 
         $variants = [];
@@ -96,7 +97,7 @@ final class Branch
         return new self(
             $name,
             $phpVersions,
-            $services,
+            $tools,
             $config['php_extensions'] ?? [],
             $variants,
             Path::fromString($config['docs_path']),
@@ -119,11 +120,11 @@ final class Branch
     }
 
     /**
-     * @return Service[]
+     * @return Tool[]
      */
-    public function services(): array
+    public function tools(): array
     {
-        return $this->services;
+        return $this->tools;
     }
 
     /**
@@ -134,17 +135,17 @@ final class Branch
         return $this->phpExtensions;
     }
 
-    public function hasService(string $serviceName): bool
+    public function hasTool(string $toolName): bool
     {
-        if ([] === $this->services) {
+        if ([] === $this->tools) {
             return false;
         }
 
-        $serviceNames = array_map(static function (Service $service): string {
-            return $service->toString();
-        }, $this->services());
+        $toolNames = array_map(static function (Tool $tool): string {
+            return $tool->toString();
+        }, $this->tools());
 
-        return \in_array($serviceName, $serviceNames, true);
+        return \in_array($toolName, $toolNames, true);
     }
 
     /**

--- a/src/Domain/Value/Branch.php
+++ b/src/Domain/Value/Branch.php
@@ -136,15 +136,13 @@ final class Branch
 
     public function hasTool(string $toolName): bool
     {
-        if ([] === $this->tools) {
-            return false;
+        foreach ($this->tools() as $tool) {
+            if ($tool->toString() === $toolName) {
+                return true;
+            }
         }
 
-        $toolNames = array_map(static function (Tool $tool): string {
-            return $tool->toString();
-        }, $this->tools());
-
-        return \in_array($toolName, $toolNames, true);
+        return false;
     }
 
     /**

--- a/src/Domain/Value/Branch.php
+++ b/src/Domain/Value/Branch.php
@@ -126,6 +126,17 @@ final class Branch
         return $this->tools;
     }
 
+    public function hasTool(string $toolName): bool
+    {
+        foreach ($this->tools() as $tool) {
+            if ($tool->toString() === $toolName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @return string[]
      */
@@ -134,10 +145,10 @@ final class Branch
         return $this->phpExtensions;
     }
 
-    public function hasTool(string $toolName): bool
+    public function hasPhpExtensions(string $phpExtensionName): bool
     {
-        foreach ($this->tools() as $tool) {
-            if ($tool->toString() === $toolName) {
+        foreach ($this->phpExtensions() as $phpExtension) {
+            if ($phpExtension === $phpExtensionName || explode('-', $phpExtension)[0] === $phpExtensionName) {
                 return true;
             }
         }

--- a/src/Domain/Value/Branch.php
+++ b/src/Domain/Value/Branch.php
@@ -26,6 +26,11 @@ final class Branch
     private array $phpVersions;
 
     /**
+     * @var array<string>
+     */
+    private array $phpExtensions;
+
+    /**
      * @var Service[]
      */
     private array $services;
@@ -48,6 +53,7 @@ final class Branch
         string $name,
         array $phpVersions,
         array $services,
+        array $phpExtensions,
         array $variants,
         Path $docsPath,
         Path $testsPath,
@@ -56,6 +62,7 @@ final class Branch
         $this->name = TrimmedNonEmptyString::fromString($name)->toString();
         $this->phpVersions = $phpVersions;
         $this->services = $services;
+        $this->phpExtensions = $phpExtensions;
         $this->variants = $variants;
         $this->docsPath = $docsPath;
         $this->testsPath = $testsPath;
@@ -89,6 +96,7 @@ final class Branch
         return new self(
             $name,
             $phpVersions,
+            $config['php_extensions'],
             $services,
             $variants,
             Path::fromString($config['docs_path']),
@@ -116,6 +124,14 @@ final class Branch
     public function services(): array
     {
         return $this->services;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function phpExtensions(): array
+    {
+        return $this->phpExtensions;
     }
 
     public function hasService(string $serviceName): bool

--- a/src/Domain/Value/Tool.php
+++ b/src/Domain/Value/Tool.php
@@ -16,7 +16,7 @@ namespace App\Domain\Value;
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class Service
+final class Tool
 {
     private string $name;
 

--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -31,12 +31,8 @@ jobs:
               with:
                   php-version: {{ branch.targetPhpVersion.toString }}
                   coverage: none
-{% if branch.hasService('mongodb') %}
-                  tools: composer:v{{ project.composerVersion }}, pecl
-                  extensions: mongodb
-{% else %}
-                  tools: composer:v{{ project.composerVersion }}
-{% endif %}
+                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.tools)|join(', ') }}
+                  extensions: {{ branch.phpExtensions|join(', ') }}
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}

--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -66,12 +66,8 @@ jobs:
               with:
                   php-version: {{ branch.targetPhpVersion.toString }}
                   coverage: none
-{% if branch.hasService('mongodb') %}
-                  tools: composer:v{{ project.composerVersion }}, pecl
-                  extensions: mongodb
-{% else %}
-                  tools: composer:v{{ project.composerVersion }}
-{% endif %}
+                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.tools)|join(', ') }}
+                  extensions: {{ branch.phpExtensions|join(', ') }}
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -69,7 +69,7 @@ jobs:
                   {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
                   coverage: pcov
 
-                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.services)|join(, ) }}
+                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.services)|join(', ') }}
                   extensions: {{ branch.phpExtensions|join(, ) }}
 
 

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -68,9 +68,8 @@ jobs:
               with:
                   {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
                   coverage: pcov
-
-                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.services)|join(', ') }}
-                  extensions: {{ branch.phpExtensions|join(, ) }}
+                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.tools)|join(', ') }}
+                  extensions: {{ branch.phpExtensions|join(', ') }}
 
 
             - name: Add PHPUnit matcher

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -69,7 +69,7 @@ jobs:
                   {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
                   coverage: pcov
 
-                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.tools)|join(, ) }}
+                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.services)|join(, ) }}
                   extensions: {{ branch.phpExtensions|join(, ) }}
 
 

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -71,9 +71,10 @@ jobs:
 {% if branch.hasService('mongodb') %}
                   tools: composer:v{{ project.composerVersion }}, pecl
 {# Change mongodb extension version to a stable one when available #}
-                  extensions: mongodb-1.9.0
+                  extensions: mongodb-1.9.0, {{ branch.phpExtensions|join(, ) }}
 {% else %}
                   tools: composer:v{{ project.composerVersion }}
+                  extensions: {{ branch.phpExtensions|join(, ) }}
 {% endif %}
 
             - name: Add PHPUnit matcher

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -68,14 +68,10 @@ jobs:
               with:
                   {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
                   coverage: pcov
-{% if branch.hasService('mongodb') %}
-                  tools: composer:v{{ project.composerVersion }}, pecl
-{# Change mongodb extension version to a stable one when available #}
-                  extensions: mongodb-1.9.0, {{ branch.phpExtensions|join(, ) }}
-{% else %}
-                  tools: composer:v{{ project.composerVersion }}
+
+                  tools: composer:v{{ project.composerVersion }}{% if branch.hasService('mongodb') %}, pecl{% endif %}
                   extensions: {{ branch.phpExtensions|join(, ) }}
-{% endif %}
+
 
             - name: Add PHPUnit matcher
               {% verbatim %}run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"{% endverbatim %}

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -23,7 +23,7 @@ jobs:
 
         {% verbatim %}continue-on-error: ${{ matrix.allowed-to-fail }}{% endverbatim %}
 
-{% if branch.hasService('mongodb') %}
+{% if branch.hasTool('mongodb') %}
         services:
             mongo:
                 image: mongo

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -69,7 +69,7 @@ jobs:
                   {% verbatim %}php-version: ${{ matrix.php-version }}{% endverbatim %}
                   coverage: pcov
 
-                  tools: composer:v{{ project.composerVersion }}{% if branch.hasService('mongodb') %}, pecl{% endif %}
+                  tools: {{ ['composer:v' ~ {{ project.composerVersion }}]|merge(branch.tools)|join(, ) }}
                   extensions: {{ branch.phpExtensions|join(, ) }}
 
 

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -23,7 +23,7 @@ jobs:
 
         {% verbatim %}continue-on-error: ${{ matrix.allowed-to-fail }}{% endverbatim %}
 
-{% if branch.hasTool('mongodb') %}
+{% if branch.hasPhpExtensions('mongodb') %}
         services:
             mongo:
                 image: mongo

--- a/tests/Domain/Value/BranchTest.php
+++ b/tests/Domain/Value/BranchTest.php
@@ -27,7 +27,7 @@ master:
   variants:
     symfony/symfony: ['4.4']
     sonata-project/block-bundle: ['4']
-  services: []
+  tools: []
   docs_path: docs
   tests_path: tests
 CONFIG;
@@ -52,16 +52,16 @@ CONFIG;
         self::assertSame('7.3', $branch->lowestPhpVersion()->toString());
         self::assertSame('8.0', $branch->highestPhpVersion()->toString());
         self::assertCount(2, $branch->variants());
-        self::assertEmpty($branch->services());
+        self::assertEmpty($branch->tools());
         self::assertSame('docs', $branch->docsPath()->toString());
         self::assertSame('tests', $branch->testsPath()->toString());
-        self::assertFalse($branch->hasService('foo'));
+        self::assertFalse($branch->hasTool('foo'));
     }
 
     /**
      * @test
      */
-    public function hasService(): void
+    public function hasTool(): void
     {
         $name = 'master';
 
@@ -72,7 +72,7 @@ master:
   variants:
     symfony/symfony: ['4.4']
     sonata-project/block-bundle: ['4']
-  services: ['mongodb']
+  tools: ['mongodb']
   docs_path: docs
   tests_path: tests
 CONFIG;
@@ -84,6 +84,6 @@ CONFIG;
             $config[self::DEFAULT_BRANCH_NAME]
         );
 
-        self::assertTrue($branch->hasService('mongodb'));
+        self::assertTrue($branch->hasTool('mongodb'));
     }
 }

--- a/tests/Domain/Value/ProjectTest.php
+++ b/tests/Domain/Value/ProjectTest.php
@@ -39,7 +39,7 @@ admin-bundle:
       variants:
         symfony/symfony: ['4.4']
         sonata-project/block-bundle: ['4']
-      services: []
+      tools: []
       docs_path: docs
       tests_path: tests
     3.x:
@@ -48,7 +48,7 @@ admin-bundle:
       variants:
         symfony/symfony: ['4.4']
         sonata-project/block-bundle: ['3']
-      services: []
+      tools: []
       docs_path: docs
       tests_path: tests
 CONFIG;

--- a/tests/Github/Domain/Value/Search/QueryTest.php
+++ b/tests/Github/Domain/Value/Search/QueryTest.php
@@ -77,7 +77,7 @@ master:
   variants:
     symfony/symfony: ['4.4']
     sonata-project/block-bundle: ['4']
-  services: []
+  tools: []
   docs_path: docs
   tests_path: tests
 CONFIG;


### PR DESCRIPTION
IMO we can now remove curl and install directly mango from PHP extensions.
Also `soap` and `gd` must be add to MediaBundle to php 7.3.

Proof PR: https://github.com/sonata-project/SonataMediaBundle/pull/1926  
