### PR TITLE
Remove useless "custom_gitattributes_part" definition for "admin-bundle"

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -1,8 +1,6 @@
 admin-bundle:
     phpstan: true
     psalm: true
-    custom_gitattributes_part: |
-        .phpstan export-ignore
 
     custom_gitignore_part: |
         # clean up some non bower ready package


### PR DESCRIPTION
I think we don't need a specific `export-ignore` attribute for the `.phpstan` file since all files starting with a leading dot are already covered:
https://github.com/sonata-project/dev-kit/blob/03c1489fe325aa07dbf01bfff36d369df1489224/templates/project/.gitattributes.twig#L5