### PR TITLE
Update php-cs-fixer version

### DIFF
--- a/templates/project/.github/workflows/lint.yaml.twig
+++ b/templates/project/.github/workflows/lint.yaml.twig
@@ -23,7 +23,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Run PHP-CS-Fixer
-              uses: docker://oskarstark/php-cs-fixer-ga:2.18.1
+              uses: docker://oskarstark/php-cs-fixer-ga:2.18.5
               with:
                   args: --ansi --verbose --diff --dry-run
 


### PR DESCRIPTION
Shouldn't we always use the latest version ?