### PR TITLE
Fixed the doc_dir option value

### DIFF
--- a/templates/project/.symfony.bundle.yaml.twig
+++ b/templates/project/.symfony.bundle.yaml.twig
@@ -30,7 +30,7 @@ The location of your RST doc files, defined as a relative directory
 If all the branches defined in the 'branches' option use the same
 directory, then you can define it as a string
 #}
-doc_dir: 'doc/'
+doc_dir: 'docs/'
 
 {#
 OPTIONAL


### PR DESCRIPTION
SonataAdminBundle uses `docs/`, so we need to update this value. I don't know if it's the same for all Sonata bundles 🙏 