### PR TITLE
Make build required

### DIFF
--- a/templates/project/.github/workflows/frontend.yaml.twig
+++ b/templates/project/.github/workflows/frontend.yaml.twig
@@ -10,25 +10,7 @@ on:
 {% for branch in project.branchesReverse|filter(branch => branch.hasFrontend) %}
             - {{ branch.name }}
 {% endfor %}
-        paths:
-            - assets/**
-            - webpack.config.js
-            - package.json
-            - yarn.lock
-            - .babelrc.js
-            - .eslintrc.js
-            - .stylelintrc.js
-            - postcss.config.js
     pull_request:
-        paths:
-            - assets/**
-            - webpack.config.js
-            - package.json
-            - yarn.lock
-            - .babelrc.js
-            - .eslintrc.js
-            - .stylelintrc.js
-            - postcss.config.js
 
 jobs:
     webpack-encore:


### PR DESCRIPTION
If we want to make the build required, we should remove the paths options, because the build will always be required no matter what files get edited.