### PR TITLE
Do not display abandoned projects

### DIFF
--- a/src/Controller/NextReleaseOverviewController.php
+++ b/src/Controller/NextReleaseOverviewController.php
@@ -42,6 +42,10 @@ final class NextReleaseOverviewController
     public function __invoke(): Response
     {
         $releases = array_reduce($this->projects->all(), function (array $releases, Project $project): array {
+            if ($project->package()->isAbandoned()) {
+                return $releases;
+            }
+
             foreach ($project->branches() as $branch) {
                 if ('master' === $branch->name() && $project->isStable()) {
                     continue;


### PR DESCRIPTION
I'm trying to reduce the number of githubAPI request we're doing in order to avoid 500 in the dev-kit website.

I don't think we have to track release for abandoned project. This saves some requests.

I looked at the request done and the issue is with the code
```
$pullRequests = $this->pullRequests->search(
     $repository,
     Query::pullRequestsSince($repository, $branch, $currentRelease->publishedAt(), AbstractCommand::SONATA_CI_BOT)
);
```
In order to fetch all the PR of the possible release. But this is doing a request per PR:
```
public function search(Repository $repository, Query $query): array
    {
        return array_map(function (array $searchResponse) use ($repository): PullRequest {
            $issue = Issue::fromInt($searchResponse['number']);

            $response = $this->github->pullRequests()->show(
                $repository->username(),
                $repository->name(),
                $issue->toInt()
            );

            return PullRequest::fromResponse($response);
        }, $this->githubPager->fetchAll($this->github->search(), 'issues', [$query->toString()]));
    }
```

And we're excluding `SonataCI` author, but we also have a lot of PR like this one:
https://api.github.com/repos/sonata-project/SonataDashboardBundle/pulls/303

What should we do to exclude these too @OskarStark ?