### PR TITLE
Avoid exception when looking for a release without changelog

### DIFF
--- a/src/Domain/Exception/CannotGenerateChangelog.php
+++ b/src/Domain/Exception/CannotGenerateChangelog.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Domain\Exception;
+
+use App\Domain\Value\NextRelease;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class CannotGenerateChangelog extends \LogicException
+{
+    public static function forRelease(NextRelease $nextRelease, ?\Throwable $previous = null): self
+    {
+        return new self(
+            sprintf(
+                'Release "%s" cannot be released yet. Please check labels and changelogs of the pull requests.',
+                $nextRelease->nextTag()->toString()
+            ),
+            0,
+            $previous
+        );
+    }
+}

--- a/templates/releases/project.html.twig
+++ b/templates/releases/project.html.twig
@@ -20,14 +20,21 @@
     {% endif %}
 
     {% if release.isNeeded %}
-        <h2>Changelog</h2>
-        <p>
-            {{ release.changelog.asMarkdown|markdown_to_html }}
-        </p>
+        {% if release.canBeReleased %}
+            <h2>Changelog</h2>
+            <p>
+                {{ release.changelog.asMarkdown|markdown_to_html }}
+            </p>
 
-        <h2>Changelog as Markdown</h2>
-        <textarea cols="140" rows="60">{{ release.changelog.asMarkdown }}</textarea>
+            <h2>Changelog as Markdown</h2>
+            <textarea cols="140" rows="60">{{ release.changelog.asMarkdown }}</textarea>
+        {% else %}
+            <h2>Next release would be: {{ release.nextTag.toString }}, but cannot be released yet</h2>
+            <p>
+                Please check labels and changelogs of the pull requests
+            </p>
+        {% endif %}
     {% else %}
-        <h1>No Release needed for {{ release.project.title }}</h1>
+        <h2>No Release needed for {{ release.project.title }}</h2>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
The Exporter has only one PR without changelog.

Trying to call the Changelog method with an empty changelog was giving an exception.
I added a check in the twig view.

Also, as the changelog is not needed as long as the release is not ready, I added a LogicException to fail faster.

Names may be improved if you have better idea.