### PR TITLE
Exclude node modules from linter

### DIFF
--- a/templates/project/.php_cs.dist
+++ b/templates/project/.php_cs.dist
@@ -63,6 +63,7 @@ $rules = [
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
+    ->exclude('node_modules')
     ->exclude('Resources/skeleton')
     ->exclude('Resources/public/vendor')
     ->exclude('var')


### PR DESCRIPTION
phpcs was running on some php files of node_modules of the Admin bundle.