### PR TITLE
Use 2 spaces to indent xliff files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -62,5 +62,8 @@ jobs:
             - name: Install required dependencies
               run: sudo apt-get update && sudo apt-get install libxml2-utils
 
-            - name: Lint files
+            - name: Lint xml files
               run: make lint-xml
+
+            - name: Lint xliff files
+              run: make lint-xliff

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all:
 	@echo "Please choose a task."
 .PHONY: all
 
-lint: lint-composer lint-yaml lint-xml lint-php
+lint: lint-composer lint-yaml lint-xml lint-xliff lint-php
 .PHONY: lint
 
 lint-composer:
@@ -19,7 +19,7 @@ lint-yaml:
 .PHONY: lint-yaml
 
 lint-xml:
-	find . \( -name '*.xml' -or -name '*.xliff' \) \
+	find . -name '*.xml' \
 		-not -path './vendor/*' \
 		-not -path './src/Resources/public/vendor/*' \
 		| while read xmlFile; \
@@ -29,6 +29,18 @@ lint-xml:
 	done
 
 .PHONY: lint-xml
+
+lint-xliff:
+	find . -name '*.xliff' \
+		-not -path './vendor/*' \
+		-not -path './src/Resources/public/vendor/*' \
+		| while read xmlFile; \
+	do \
+		XMLLINT_INDENT='  ' xmllint --encode UTF-8 --format "$$xmlFile"|diff - "$$xmlFile"; \
+		if [ $$? -ne 0 ] ;then exit 1; fi; \
+	done
+
+.PHONY: lint-xliff
 
 lint-php:
 	php-cs-fixer fix --ansi --verbose --diff --dry-run

--- a/templates/project/.editorconfig
+++ b/templates/project/.editorconfig
@@ -11,13 +11,13 @@ charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{yaml,yml,twig,php}]
+[*.{xml,yaml,yml,twig,php}]
 indent_size = 4
 
 [.yamllint]
 indent_size = 4
 
-[*.{js,json,scss,css}]
+[*.{xliff,js,json,scss,css}]
 indent_size = 2
 
 [composer.json]

--- a/templates/project/.github/workflows/lint.yaml.twig
+++ b/templates/project/.github/workflows/lint.yaml.twig
@@ -73,5 +73,8 @@ jobs:
             - name: Install required dependencies
               run: sudo apt-get update && sudo apt-get install libxml2-utils
 
-            - name: Lint files
+            - name: Lint xml files
               run: make lint-xml
+
+            - name: Lint xliff files
+              run: make lint-xliff

--- a/templates/project/Makefile.twig
+++ b/templates/project/Makefile.twig
@@ -6,7 +6,7 @@ all:
 	@echo "Please choose a task."
 .PHONY: all
 
-lint: lint-composer lint-yaml lint-xml lint-php
+lint: lint-composer lint-yaml lint-xml lint-xliff lint-php
 .PHONY: lint
 
 lint-composer:
@@ -19,7 +19,7 @@ lint-yaml:
 .PHONY: lint-yaml
 
 lint-xml:
-	find . \( -name '*.xml' -or -name '*.xliff' \) \
+	find . -name '*.xml' \
 		-not -path './vendor/*' \
 		-not -path './src/Resources/public/vendor/*' \
 		| while read xmlFile; \
@@ -29,6 +29,18 @@ lint-xml:
 	done
 
 .PHONY: lint-xml
+
+lint-xliff:
+	find . -name '*.xliff' \
+		-not -path './vendor/*' \
+		-not -path './src/Resources/public/vendor/*' \
+		| while read xmlFile; \
+	do \
+		XMLLINT_INDENT='  ' xmllint --encode UTF-8 --format "$$xmlFile"|diff - "$$xmlFile"; \
+		if [ $$? -ne 0 ] ;then exit 1; fi; \
+	done
+
+.PHONY: lint-xliff
 
 lint-php:
 	php-cs-fixer fix --ansi --verbose --diff --dry-run


### PR DESCRIPTION
Required for https://github.com/sonata-project/dev-kit/issues/1614 since the tools is making PR with 2 spaces