### PR TITLE
Add php_unit_test_case_static_method_calls

### DIFF
--- a/templates/project/.php-cs-fixer.dist.php
+++ b/templates/project/.php-cs-fixer.dist.php
@@ -50,6 +50,7 @@ $rules = [
     'php_unit_set_up_tear_down_visibility' => true,
     'php_unit_strict' => true,
     'php_unit_test_annotation' => false,
+    'php_unit_test_case_static_method_calls' => true,
     'phpdoc_order' => true,
     'single_line_throw' => false,
     'static_lambda' => true,
@@ -58,21 +59,18 @@ $rules = [
     'void_return' => false,
 ];
 
-
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude('node_modules')
     ->exclude('Resources/skeleton')
     ->exclude('Resources/public/vendor')
-    ->exclude('var')
-;
+    ->exclude('var');
 
 $config = new PhpCsFixer\Config();
 $config
     ->setFinder($finder)
     ->setRiskyAllowed(true)
     ->setRules($rules)
-    ->setUsingCache(true)
-;
+    ->setUsingCache(true);
 
 return $config;

--- a/tests/Action/DetermineNextReleaseVersionTest.php
+++ b/tests/Action/DetermineNextReleaseVersionTest.php
@@ -32,7 +32,7 @@ final class DetermineNextReleaseVersionTest extends TestCase
     {
         $tag = Tag::fromString('1.1.0');
 
-        self::assertSame(
+        static::assertSame(
             $tag,
             DetermineNextReleaseVersion::forTagAndPullRequests($tag, [])
         );
@@ -49,7 +49,7 @@ final class DetermineNextReleaseVersionTest extends TestCase
             self::createPullRequestWithStability(Stability::unknown()),
         ];
 
-        self::assertSame(
+        static::assertSame(
             $tag,
             DetermineNextReleaseVersion::forTagAndPullRequests($tag, $pullRequests)
         );
@@ -66,7 +66,7 @@ final class DetermineNextReleaseVersionTest extends TestCase
 
         $nextVersion = DetermineNextReleaseVersion::forTagAndPullRequests($tag, $pullRequests)->toString();
 
-        self::assertSame(
+        static::assertSame(
             $expected,
             $nextVersion
         );
@@ -157,7 +157,7 @@ final class DetermineNextReleaseVersionTest extends TestCase
 
         $pullRequest = PullRequest::fromResponse($response);
 
-        self::assertSame(
+        static::assertSame(
             $stability->toString(),
             $pullRequest->stability()->toString()
         );

--- a/tests/Action/Exception/CannotDeterminNextReleaseTest.php
+++ b/tests/Action/Exception/CannotDeterminNextReleaseTest.php
@@ -47,11 +47,11 @@ final class CannotDeterminNextReleaseTest extends TestCase
 
         $cannotDetermineNextRelease = CannotDetermineNextRelease::forBranch($project, $branch);
 
-        self::assertInstanceOf(
+        static::assertInstanceOf(
             \RuntimeException::class,
             $cannotDetermineNextRelease
         );
-        self::assertSame(
+        static::assertSame(
             sprintf(
                 'Cannot determine next release for branch "%s" of project "%s".',
                 $branch->name(),

--- a/tests/Action/Exception/NoPullRequestMergedSinceLastReleaseTest.php
+++ b/tests/Action/Exception/NoPullRequestMergedSinceLastReleaseTest.php
@@ -53,11 +53,11 @@ final class NoPullRequestMergedSinceLastReleaseTest extends TestCase
             $lastRelease
         );
 
-        self::assertInstanceOf(
+        static::assertInstanceOf(
             \RuntimeException::class,
             $cannotDetermineNextRelease
         );
-        self::assertSame(
+        static::assertSame(
             sprintf(
                 'No pull requests merged since last release "%s" for branch "%s" of project "%s".',
                 $datetime,

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -62,7 +62,7 @@ final class DispatchFilesCommandTest extends TestCase
             'branch' => $project->branches()[0],
         ]);
 
-        $this->assertSame($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     /**

--- a/tests/Config/Exception/UnknownBranchTest.php
+++ b/tests/Config/Exception/UnknownBranchTest.php
@@ -48,11 +48,11 @@ final class UnknownBranchTest extends TestCase
 
         $unknownBranch = UnknownBranch::forName($project, $name);
 
-        self::assertInstanceOf(
+        static::assertInstanceOf(
             \InvalidArgumentException::class,
             $unknownBranch
         );
-        self::assertSame(
+        static::assertSame(
             sprintf(
                 'Could not find branch with name "%s" for project "%s".',
                 $name,

--- a/tests/Config/Exception/UnknownProjectTest.php
+++ b/tests/Config/Exception/UnknownProjectTest.php
@@ -30,11 +30,11 @@ final class UnknownProjectTest extends TestCase
 
         $unknownProject = UnknownProject::forName($name);
 
-        self::assertInstanceOf(
+        static::assertInstanceOf(
             \InvalidArgumentException::class,
             $unknownProject
         );
-        self::assertSame(
+        static::assertSame(
             sprintf(
                 'Could not find project with name "%s".',
                 $name

--- a/tests/Domain/Exception/NoBranchesAvaillableTest.php
+++ b/tests/Domain/Exception/NoBranchesAvaillableTest.php
@@ -46,11 +46,11 @@ final class NoBranchesAvaillableTest extends TestCase
 
         $noBranchesAvailable = NoBranchesAvailable::forProject($project);
 
-        self::assertInstanceOf(
+        static::assertInstanceOf(
             \InvalidArgumentException::class,
             $noBranchesAvailable
         );
-        self::assertSame(
+        static::assertSame(
             sprintf(
                 'Project "%s" has no branches configured.',
                 $project->name()

--- a/tests/Domain/Value/BranchTest.php
+++ b/tests/Domain/Value/BranchTest.php
@@ -49,17 +49,17 @@ CONFIG;
             $config[self::DEFAULT_BRANCH_NAME]
         );
 
-        self::assertSame($name, $branch->name());
-        self::assertCount(3, $branch->phpVersions());
-        self::assertSame('7.4', $branch->targetPhpVersion()->toString());
-        self::assertSame('7.3', $branch->lowestPhpVersion()->toString());
-        self::assertSame('8.0', $branch->highestPhpVersion()->toString());
-        self::assertCount(2, $branch->variants());
-        self::assertSame('docs', $branch->docsPath()->toString());
-        self::assertSame('tests', $branch->testsPath()->toString());
-        self::assertTrue($branch->hasFrontend());
-        self::assertNull($branch->customGitignorePart());
-        self::assertTrue($branch->hasTool('foo'));
-        self::assertTrue($branch->hasPhpExtension('bar'));
+        static::assertSame($name, $branch->name());
+        static::assertCount(3, $branch->phpVersions());
+        static::assertSame('7.4', $branch->targetPhpVersion()->toString());
+        static::assertSame('7.3', $branch->lowestPhpVersion()->toString());
+        static::assertSame('8.0', $branch->highestPhpVersion()->toString());
+        static::assertCount(2, $branch->variants());
+        static::assertSame('docs', $branch->docsPath()->toString());
+        static::assertSame('tests', $branch->testsPath()->toString());
+        static::assertTrue($branch->hasFrontend());
+        static::assertNull($branch->customGitignorePart());
+        static::assertTrue($branch->hasTool('foo'));
+        static::assertTrue($branch->hasPhpExtension('bar'));
     }
 }

--- a/tests/Domain/Value/ProjectTest.php
+++ b/tests/Domain/Value/ProjectTest.php
@@ -79,23 +79,23 @@ CONFIG;
             $package
         );
 
-        self::assertSame(self::DEFAULT_CONFIG_NAME, $project->name());
-        self::assertSame('SonataAdminBundle', $project->title());
-        self::assertSame($packageName, $project->package()->getName());
-        self::assertTrue($project->hasBranches());
-        self::assertCount(2, $project->branches());
-        self::assertSame(['master', '3.x'], $project->branchNames());
-        self::assertSame(['3.x', 'master'], $project->branchNamesReverse());
-        self::assertSame('master', $project->unstableBranch()->name());
-        self::assertSame('3.x', $project->stableBranch()->name());
-        self::assertTrue($project->usesPHPStan());
-        self::assertTrue($project->usesPsalm());
-        self::assertTrue($project->usesPanther());
-        self::assertNull($project->customGitignorePart());
-        self::assertNull($project->customGitattributesPart());
-        self::assertTrue($project->hasDocumentation());
-        self::assertSame('1', $project->composerVersion());
-        self::assertTrue($project->isBundle());
+        static::assertSame(self::DEFAULT_CONFIG_NAME, $project->name());
+        static::assertSame('SonataAdminBundle', $project->title());
+        static::assertSame($packageName, $project->package()->getName());
+        static::assertTrue($project->hasBranches());
+        static::assertCount(2, $project->branches());
+        static::assertSame(['master', '3.x'], $project->branchNames());
+        static::assertSame(['3.x', 'master'], $project->branchNamesReverse());
+        static::assertSame('master', $project->unstableBranch()->name());
+        static::assertSame('3.x', $project->stableBranch()->name());
+        static::assertTrue($project->usesPHPStan());
+        static::assertTrue($project->usesPsalm());
+        static::assertTrue($project->usesPanther());
+        static::assertNull($project->customGitignorePart());
+        static::assertNull($project->customGitattributesPart());
+        static::assertTrue($project->hasDocumentation());
+        static::assertSame('1', $project->composerVersion());
+        static::assertTrue($project->isBundle());
     }
 
     /**
@@ -119,7 +119,7 @@ CONFIG;
             $package
         );
 
-        self::assertSame($expected, $project->isBundle());
+        static::assertSame($expected, $project->isBundle());
     }
 
     /**
@@ -216,7 +216,7 @@ CONFIG,
             $package
         );
 
-        self::assertSame(
+        static::assertSame(
             $expected,
             $project->homepage()
         );
@@ -265,7 +265,7 @@ CONFIG,
             $package
         );
 
-        self::assertSame(
+        static::assertSame(
             $expected,
             $project->description()
         );
@@ -340,7 +340,7 @@ CONFIG,
             sort($expected);
         }
 
-        self::assertSame(
+        static::assertSame(
             $expected,
             $project->topics()
         );
@@ -370,7 +370,7 @@ CONFIG,
             $package
         );
 
-        self::assertNotEmpty($project->topics());
+        static::assertNotEmpty($project->topics());
     }
 
     /**
@@ -415,7 +415,7 @@ CONFIG,
             sort($expected);
         }
 
-        self::assertSame(
+        static::assertSame(
             $expected,
             $project->topics()
         );
@@ -442,7 +442,7 @@ CONFIG,
             $package
         );
 
-        self::assertSame($expected, $project->documentationBadgeSlug());
+        static::assertSame($expected, $project->documentationBadgeSlug());
     }
 
     /**
@@ -532,7 +532,7 @@ CONFIG,
             $package
         );
 
-        self::assertSame($expected, $project->defaultBranch()->name());
+        static::assertSame($expected, $project->defaultBranch()->name());
     }
 
     /**

--- a/tests/Domain/Value/RepositoryTest.php
+++ b/tests/Domain/Value/RepositoryTest.php
@@ -32,8 +32,8 @@ final class RepositoryTest extends TestCase
 
         $repository = Repository::fromPackage($package);
 
-        self::assertSame('sonata-project', $repository->username());
-        self::assertSame('SonataAdminBundle', $repository->name());
-        self::assertSame('sonata-project/SonataAdminBundle', $repository->toString());
+        static::assertSame('sonata-project', $repository->username());
+        static::assertSame('SonataAdminBundle', $repository->name());
+        static::assertSame('sonata-project/SonataAdminBundle', $repository->toString());
     }
 }

--- a/tests/Domain/Value/StabilityTest.php
+++ b/tests/Domain/Value/StabilityTest.php
@@ -39,7 +39,7 @@ final class StabilityTest extends TestCase
      */
     public function usesLowercaseForStability(): void
     {
-        self::assertSame(
+        static::assertSame(
             'minor',
             Stability::fromString('MINOR')->toString()
         );
@@ -50,7 +50,7 @@ final class StabilityTest extends TestCase
      */
     public function toStringReturnsLowercaseString(): void
     {
-        self::assertSame(
+        static::assertSame(
             'minor',
             Stability::minor()->toString()
         );
@@ -61,7 +61,7 @@ final class StabilityTest extends TestCase
      */
     public function toUppercaseStringReturnsUppercaseString(): void
     {
-        self::assertSame(
+        static::assertSame(
             'MINOR',
             Stability::minor()->toUppercaseString()
         );
@@ -76,7 +76,7 @@ final class StabilityTest extends TestCase
     {
         $stability = Stability::fromString($value);
 
-        self::assertSame($value, $stability->toString());
+        static::assertSame($value, $stability->toString());
     }
 
     /**
@@ -94,7 +94,7 @@ final class StabilityTest extends TestCase
      */
     public function patch()
     {
-        self::assertSame(
+        static::assertSame(
             'patch',
             Stability::patch()->toString()
         );
@@ -105,7 +105,7 @@ final class StabilityTest extends TestCase
      */
     public function minor()
     {
-        self::assertSame(
+        static::assertSame(
             'minor',
             Stability::minor()->toString()
         );
@@ -116,7 +116,7 @@ final class StabilityTest extends TestCase
      */
     public function pedantic()
     {
-        self::assertSame(
+        static::assertSame(
             'pedantic',
             Stability::pedantic()->toString()
         );
@@ -127,7 +127,7 @@ final class StabilityTest extends TestCase
      */
     public function unknown()
     {
-        self::assertSame(
+        static::assertSame(
             'unknown',
             Stability::unknown()->toString()
         );
@@ -140,12 +140,12 @@ final class StabilityTest extends TestCase
      */
     public function equals(bool $expected, Stability $stability, Stability $other): void
     {
-        self::assertSame(
+        static::assertSame(
             $expected,
             $stability->equals($other)
         );
 
-        self::assertSame(
+        static::assertSame(
             !$expected,
             $stability->notEquals($other)
         );

--- a/tests/Domain/Value/TrimmedNonEmptyStringTest.php
+++ b/tests/Domain/Value/TrimmedNonEmptyStringTest.php
@@ -28,7 +28,7 @@ final class TrimmedNonEmptyStringTest extends TestCase
     {
         $string = self::faker()->word();
 
-        self::assertSame(
+        static::assertSame(
             $string,
             TrimmedNonEmptyString::fromString($string)->toString()
         );
@@ -42,7 +42,7 @@ final class TrimmedNonEmptyStringTest extends TestCase
         $string = self::faker()->word();
         $untrimmed = ' '.$string.' ';
 
-        self::assertSame(
+        static::assertSame(
             $string,
             TrimmedNonEmptyString::fromString($untrimmed)->toString()
         );

--- a/tests/Domain/Value/VariantTest.php
+++ b/tests/Domain/Value/VariantTest.php
@@ -82,9 +82,9 @@ final class VariantTest extends TestCase
     {
         $variant = Variant::fromValues($package, $version);
 
-        self::assertSame($package, $variant->package());
-        self::assertSame($version, $variant->version());
-        self::assertSame($expected, $variant->toString());
+        static::assertSame($package, $variant->package());
+        static::assertSame($version, $variant->version());
+        static::assertSame($expected, $variant->toString());
     }
 
     /**

--- a/tests/Github/Domain/Value/CheckRunsTest.php
+++ b/tests/Github/Domain/Value/CheckRunsTest.php
@@ -51,7 +51,7 @@ final class CheckRunsTest extends TestCase
             ],
         ]);
 
-        self::assertSame(
+        static::assertSame(
             $expected,
             CheckRuns::fromResponse($response)->isSuccessful()
         );
@@ -87,7 +87,7 @@ final class CheckRunsTest extends TestCase
         $checkRuns = CheckRuns::fromResponse($response);
         $runs = $checkRuns->all();
 
-        self::assertCount(2, $runs);
+        static::assertCount(2, $runs);
         self::assertCheckRunEqualsCheckRun(
             $checkRun1 = CheckRun::fromResponse($response1),
             $runs[$checkRun1->name()]
@@ -119,7 +119,7 @@ final class CheckRunsTest extends TestCase
 
         $runs = CheckRuns::fromResponse($response)->all();
 
-        self::assertSame(
+        static::assertSame(
             [
                 'Bar',
                 'foo',
@@ -131,10 +131,10 @@ final class CheckRunsTest extends TestCase
 
     private static function assertCheckRunEqualsCheckRun(CheckRun $expected, CheckRun $other): void
     {
-        self::assertSame($expected->status(), $other->status());
-        self::assertSame($expected->conclusion(), $other->conclusion());
-        self::assertSame($expected->name(), $other->name());
-        self::assertSame($expected->detailsUrl(), $other->detailsUrl());
-        self::assertSame($expected->isSuccessful(), $other->isSuccessful());
+        static::assertSame($expected->status(), $other->status());
+        static::assertSame($expected->conclusion(), $other->conclusion());
+        static::assertSame($expected->name(), $other->name());
+        static::assertSame($expected->detailsUrl(), $other->detailsUrl());
+        static::assertSame($expected->isSuccessful(), $other->isSuccessful());
     }
 }

--- a/tests/Github/Domain/Value/CombinedStatusTest.php
+++ b/tests/Github/Domain/Value/CombinedStatusTest.php
@@ -130,7 +130,7 @@ final class CombinedStatusTest extends TestCase
 
         $response['statuses'] = [];
 
-        self::assertSame(
+        static::assertSame(
             [],
             CombinedStatus::fromResponse($response)->statuses()
         );
@@ -147,7 +147,7 @@ final class CombinedStatusTest extends TestCase
             'state' => $state,
         ]);
 
-        self::assertSame(
+        static::assertSame(
             $state,
             CombinedStatus::fromResponse($response)->state()
         );
@@ -174,7 +174,7 @@ final class CombinedStatusTest extends TestCase
             'state' => $state,
         ]);
 
-        self::assertSame(
+        static::assertSame(
             $expected,
             CombinedStatus::fromResponse($response)->isSuccessful()
         );
@@ -205,7 +205,7 @@ final class CombinedStatusTest extends TestCase
         $combined = CombinedStatus::fromResponse($response);
         $statuses = $combined->statuses();
 
-        self::assertCount(2, $statuses);
+        static::assertCount(2, $statuses);
         self::assertStatusEqualsStatus(
             Status::fromResponse($statusResponse1),
             $statuses[0]
@@ -218,9 +218,9 @@ final class CombinedStatusTest extends TestCase
 
     private static function assertStatusEqualsStatus(Status $expected, Status $other): void
     {
-        self::assertSame($expected->state(), $other->state());
-        self::assertSame($expected->description(), $other->description());
-        self::assertSame($expected->targetUrl(), $other->targetUrl());
-        self::assertSame($expected->isSuccessful(), $other->isSuccessful());
+        static::assertSame($expected->state(), $other->state());
+        static::assertSame($expected->description(), $other->description());
+        static::assertSame($expected->targetUrl(), $other->targetUrl());
+        static::assertSame($expected->isSuccessful(), $other->isSuccessful());
     }
 }

--- a/tests/Github/Domain/Value/Commit/CommitCollectionTest.php
+++ b/tests/Github/Domain/Value/Commit/CommitCollectionTest.php
@@ -56,7 +56,7 @@ final class CommitCollectionTest extends TestCase
             ]),
         ];
 
-        self::assertInstanceOf(
+        static::assertInstanceOf(
             \Countable::class,
             CommitCollection::from($commits)
         );
@@ -90,11 +90,11 @@ final class CommitCollectionTest extends TestCase
 
         $collection = CommitCollection::from($commits);
 
-        self::assertSame(
+        static::assertSame(
             2,
             $collection->count()
         );
-        self::assertCount(
+        static::assertCount(
             2,
             $collection
         );
@@ -126,7 +126,7 @@ final class CommitCollectionTest extends TestCase
             ]),
         ];
 
-        self::assertSame(
+        static::assertSame(
             1,
             (CommitCollection::from($commits))->uniqueCount()
         );
@@ -158,7 +158,7 @@ final class CommitCollectionTest extends TestCase
             ]),
         ];
 
-        self::assertSame(
+        static::assertSame(
             $firstMessage,
             (CommitCollection::from($commits))->firstMessage()
         );
@@ -190,7 +190,7 @@ final class CommitCollectionTest extends TestCase
             ]),
         ];
 
-        self::assertSame(
+        static::assertSame(
             [
                 $message1,
                 $message2,

--- a/tests/Github/Domain/Value/CommitTest.php
+++ b/tests/Github/Domain/Value/CommitTest.php
@@ -45,9 +45,9 @@ final class CommitTest extends TestCase
 
         $commit = Commit::fromResponse($response);
 
-        self::assertSame($sha, $commit->sha()->toString());
-        self::assertSame($message, $commit->message());
-        self::assertSame(
+        static::assertSame($sha, $commit->sha()->toString());
+        static::assertSame($message, $commit->message());
+        static::assertSame(
             (new \DateTimeImmutable($date))->getTimestamp(),
             $commit->date()->getTimestamp()
         );

--- a/tests/Github/Domain/Value/HookTest.php
+++ b/tests/Github/Domain/Value/HookTest.php
@@ -52,11 +52,11 @@ final class HookTest extends TestCase
 
         $hook = Hook::fromResponse($response);
 
-        self::assertSame($id, $hook->id());
-        self::assertSame($hookUrl, $hook->url()->toString());
-        self::assertSame($active, $hook->active());
-        self::assertTrue($hook->config()->equals($config));
-        self::assertSame($url, $hook->config()->url()->toString());
-        self::assertTrue($hook->events()->equals($events));
+        static::assertSame($id, $hook->id());
+        static::assertSame($hookUrl, $hook->url()->toString());
+        static::assertSame($active, $hook->active());
+        static::assertTrue($hook->config()->equals($config));
+        static::assertSame($url, $hook->config()->url()->toString());
+        static::assertTrue($hook->events()->equals($events));
     }
 }

--- a/tests/Github/Domain/Value/IncomingWebhook/ActionTest.php
+++ b/tests/Github/Domain/Value/IncomingWebhook/ActionTest.php
@@ -38,7 +38,7 @@ final class ActionTest extends TestCase
      */
     public function fromString(string $value): void
     {
-        self::assertSame(
+        static::assertSame(
             trim($value),
             Action::fromString($value)->toString()
         );
@@ -49,7 +49,7 @@ final class ActionTest extends TestCase
      */
     public function SYNCHRONIZE(): void
     {
-        self::assertSame(
+        static::assertSame(
             'synchronize',
             Action::SYNCHRONIZE()->toString()
         );
@@ -60,7 +60,7 @@ final class ActionTest extends TestCase
      */
     public function CREATED(): void
     {
-        self::assertSame(
+        static::assertSame(
             'created',
             Action::CREATED()->toString()
         );
@@ -73,7 +73,7 @@ final class ActionTest extends TestCase
      */
     public function equals(bool $expected, Action $action, Action $other): void
     {
-        self::assertSame(
+        static::assertSame(
             $expected,
             $action->equals($other)
         );
@@ -101,7 +101,7 @@ final class ActionTest extends TestCase
      */
     public function equalsOneOf(bool $expected, Action $action, array $others): void
     {
-        self::assertSame(
+        static::assertSame(
             $expected,
             $action->equalsOneOf($others)
         );

--- a/tests/Github/Domain/Value/IncomingWebhook/EventTest.php
+++ b/tests/Github/Domain/Value/IncomingWebhook/EventTest.php
@@ -38,7 +38,7 @@ final class EventTest extends TestCase
      */
     public function fromString(string $value): void
     {
-        self::assertSame(
+        static::assertSame(
             trim($value),
             Event::fromString($value)->toString()
         );
@@ -51,7 +51,7 @@ final class EventTest extends TestCase
      */
     public function equals(bool $expected, Event $event, Event $other): void
     {
-        self::assertSame(
+        static::assertSame(
             $expected,
             $event->equals($other)
         );
@@ -79,7 +79,7 @@ final class EventTest extends TestCase
      */
     public function equalsOneOf(bool $expected, Event $event, array $others): void
     {
-        self::assertSame(
+        static::assertSame(
             $expected,
             $event->equalsOneOf($others)
         );

--- a/tests/Github/Domain/Value/IncomingWebhook/PayloadTest.php
+++ b/tests/Github/Domain/Value/IncomingWebhook/PayloadTest.php
@@ -59,12 +59,12 @@ final class PayloadTest extends TestCase
 
         $payload = Payload::fromJsonString($json, $event);
 
-        self::assertSame($action, $payload->action()->toString());
-        self::assertSame($htmlUrl, $payload->htmlUrl()->toString());
-        self::assertSame($issue, $payload->issue()->toInt());
-        self::assertSame($issueAuthorId, $payload->issueAuthor()->id());
-        self::assertTrue($payload->isTheCommentFromTheAuthor());
-        self::assertSame($repository, $payload->repository()->toString());
+        static::assertSame($action, $payload->action()->toString());
+        static::assertSame($htmlUrl, $payload->htmlUrl()->toString());
+        static::assertSame($issue, $payload->issue()->toInt());
+        static::assertSame($issueAuthorId, $payload->issueAuthor()->id());
+        static::assertTrue($payload->isTheCommentFromTheAuthor());
+        static::assertSame($repository, $payload->repository()->toString());
     }
 
     /**
@@ -104,11 +104,11 @@ final class PayloadTest extends TestCase
 
         $payload = Payload::fromJsonString($json, $event);
 
-        self::assertSame($action, $payload->action()->toString());
-        self::assertSame($issue, $payload->issue()->toInt());
-        self::assertSame($issueAuthorId, $payload->issueAuthor()->id());
-        self::assertTrue($payload->isTheCommentFromTheAuthor());
-        self::assertSame($repository, $payload->repository()->toString());
+        static::assertSame($action, $payload->action()->toString());
+        static::assertSame($issue, $payload->issue()->toInt());
+        static::assertSame($issueAuthorId, $payload->issueAuthor()->id());
+        static::assertTrue($payload->isTheCommentFromTheAuthor());
+        static::assertSame($repository, $payload->repository()->toString());
     }
 
     /**
@@ -148,11 +148,11 @@ final class PayloadTest extends TestCase
 
         $payload = Payload::fromJsonString($json, $event);
 
-        self::assertSame($action, $payload->action()->toString());
-        self::assertSame($issue, $payload->issue()->toInt());
-        self::assertSame($issueAuthorId, $payload->issueAuthor()->id());
-        self::assertFalse($payload->isTheCommentFromTheAuthor());
-        self::assertSame($repository, $payload->repository()->toString());
+        static::assertSame($action, $payload->action()->toString());
+        static::assertSame($issue, $payload->issue()->toInt());
+        static::assertSame($issueAuthorId, $payload->issueAuthor()->id());
+        static::assertFalse($payload->isTheCommentFromTheAuthor());
+        static::assertSame($repository, $payload->repository()->toString());
     }
 
     /**
@@ -182,10 +182,10 @@ final class PayloadTest extends TestCase
 
         $payload = Payload::fromJsonString($json, $event);
 
-        self::assertSame($action, $payload->action()->toString());
-        self::assertSame($issue, $payload->issue()->toInt());
-        self::assertSame($issueAuthorId, $payload->issueAuthor()->id());
-        self::assertFalse($payload->isTheCommentFromTheAuthor());
-        self::assertSame($repository, $payload->repository()->toString());
+        static::assertSame($action, $payload->action()->toString());
+        static::assertSame($issue, $payload->issue()->toInt());
+        static::assertSame($issueAuthorId, $payload->issueAuthor()->id());
+        static::assertFalse($payload->isTheCommentFromTheAuthor());
+        static::assertSame($repository, $payload->repository()->toString());
     }
 }

--- a/tests/Github/Domain/Value/Issue/IssueTest.php
+++ b/tests/Github/Domain/Value/Issue/IssueTest.php
@@ -45,12 +45,12 @@ final class IssueTest extends TestCase
     {
         $value = 123;
 
-        self::assertSame(
+        static::assertSame(
             $value,
             Issue::fromInt($value)->toInt()
         );
 
-        self::assertSame(
+        static::assertSame(
             sprintf(
                 '#%s',
                 $value

--- a/tests/Github/Domain/Value/Label/ColorTest.php
+++ b/tests/Github/Domain/Value/Label/ColorTest.php
@@ -65,8 +65,8 @@ final class ColorTest extends TestCase
     {
         $color = Label\Color::fromString('EDEDED');
 
-        self::assertSame('ededed', $color->toString());
-        self::assertSame('#ededed', $color->asHexCode());
+        static::assertSame('ededed', $color->toString());
+        static::assertSame('#ededed', $color->asHexCode());
     }
 
     /**
@@ -76,7 +76,7 @@ final class ColorTest extends TestCase
      */
     public function equals(bool $expected, Label\Color $color, Label\Color $other): void
     {
-        self::assertSame(
+        static::assertSame(
             $expected,
             $color->equals($other)
         );

--- a/tests/Github/Domain/Value/LabelTest.php
+++ b/tests/Github/Domain/Value/LabelTest.php
@@ -41,10 +41,10 @@ final class LabelTest extends TestCase
             Label\Color::fromString('EDEDED')
         );
 
-        self::assertSame('Test', $label->name());
-        self::assertSame('ededed', $label->color()->toString());
-        self::assertSame('#ededed', $label->color()->asHexCode());
-        self::assertSame(
+        static::assertSame('Test', $label->name());
+        static::assertSame('ededed', $label->color()->toString());
+        static::assertSame('#ededed', $label->color()->asHexCode());
+        static::assertSame(
             [
                 'color' => 'ededed',
                 'name' => 'Test',
@@ -60,9 +60,9 @@ final class LabelTest extends TestCase
     {
         $label = Label::RTM();
 
-        self::assertSame('RTM', $label->name());
-        self::assertSame('ffffff', $label->color()->toString());
-        self::assertSame('#ffffff', $label->color()->asHexCode());
+        static::assertSame('RTM', $label->name());
+        static::assertSame('ffffff', $label->color()->toString());
+        static::assertSame('#ffffff', $label->color()->asHexCode());
     }
 
     /**
@@ -72,9 +72,9 @@ final class LabelTest extends TestCase
     {
         $label = Label::PendingAuthor();
 
-        self::assertSame('pending author', $label->name());
-        self::assertSame('ededed', $label->color()->toString());
-        self::assertSame('#ededed', $label->color()->asHexCode());
+        static::assertSame('pending author', $label->name());
+        static::assertSame('ededed', $label->color()->toString());
+        static::assertSame('#ededed', $label->color()->asHexCode());
     }
 
     /**
@@ -84,7 +84,7 @@ final class LabelTest extends TestCase
      */
     public function equals(bool $expected, Label $label, Label $other): void
     {
-        self::assertSame(
+        static::assertSame(
             $expected,
             $label->equals($other)
         );

--- a/tests/Github/Domain/Value/PullRequest/Head/RepoTest.php
+++ b/tests/Github/Domain/Value/PullRequest/Head/RepoTest.php
@@ -62,7 +62,7 @@ final class RepoTest extends TestCase
             'owner' => UserFactory::create(),
         ];
 
-        self::assertSame(
+        static::assertSame(
             $response['owner']['login'],
             Repo::fromResponse($response)->owner()->login()
         );

--- a/tests/Github/Domain/Value/PullRequest/HeadTest.php
+++ b/tests/Github/Domain/Value/PullRequest/HeadTest.php
@@ -140,7 +140,7 @@ final class HeadTest extends TestCase
 
         $head = Head::fromResponse($response);
 
-        self::assertSame($ref, $head->ref());
-        self::assertSame($sha, $head->sha()->toString());
+        static::assertSame($ref, $head->ref());
+        static::assertSame($sha, $head->sha()->toString());
     }
 }

--- a/tests/Github/Domain/Value/PullRequestTest.php
+++ b/tests/Github/Domain/Value/PullRequestTest.php
@@ -42,7 +42,7 @@ final class PullRequestTest extends TestCase
 
         $pullRequest = PullRequest::fromResponse($response);
 
-        self::assertSame($response['number'], $pullRequest->issue()->toInt());
+        static::assertSame($response['number'], $pullRequest->issue()->toInt());
     }
 
     /**
@@ -99,7 +99,7 @@ final class PullRequestTest extends TestCase
 
         $pullRequest = PullRequest::fromResponse($response);
 
-        self::assertSame($value, $pullRequest->title());
+        static::assertSame($value, $pullRequest->title());
     }
 
     /**
@@ -143,7 +143,7 @@ final class PullRequestTest extends TestCase
 
         $pullRequest = PullRequest::fromResponse($response);
 
-        self::assertSame(
+        static::assertSame(
             $value,
             $pullRequest->updatedAt()->format('Y-m-d\TH:i:s\Z')
         );
@@ -190,11 +190,11 @@ final class PullRequestTest extends TestCase
 
         $pullRequest = PullRequest::fromResponse($response);
 
-        self::assertSame(
+        static::assertSame(
             $value,
             $pullRequest->mergedAt()->format('Y-m-d\TH:i:s\Z')
         );
-        self::assertTrue($pullRequest->isMerged());
+        static::assertTrue($pullRequest->isMerged());
     }
 
     /**
@@ -208,8 +208,8 @@ final class PullRequestTest extends TestCase
 
         $pullRequest = PullRequest::fromResponse($response);
 
-        self::assertNull($pullRequest->mergedAt());
-        self::assertFalse($pullRequest->isMerged());
+        static::assertNull($pullRequest->mergedAt());
+        static::assertFalse($pullRequest->isMerged());
     }
 
     /**
@@ -284,23 +284,23 @@ final class PullRequestTest extends TestCase
 
         $pr = PullRequest::fromResponse($response);
 
-        self::assertSame($baseRef, $pr->base()->ref());
-        self::assertSame($headRef, $pr->head()->ref());
-        self::assertSame($headSha, $pr->head()->sha()->toString());
-        self::assertSame($ownerId, $pr->head()->repo()->owner()->id());
-        self::assertSame($ownerLogin, $pr->head()->repo()->owner()->login());
-        self::assertSame($ownerHtmlUrl, $pr->head()->repo()->owner()->htmlUrl());
-        self::assertSame($userId, $pr->user()->id());
-        self::assertSame($userLogin, $pr->user()->login());
-        self::assertSame($userHtmlUrl, $pr->user()->htmlUrl());
-        self::assertTrue($pr->isMergeable());
-        self::assertSame($body, $pr->body());
-        self::assertSame($htmlUrl, $pr->htmlUrl());
-        self::assertTrue($pr->hasLabels());
+        static::assertSame($baseRef, $pr->base()->ref());
+        static::assertSame($headRef, $pr->head()->ref());
+        static::assertSame($headSha, $pr->head()->sha()->toString());
+        static::assertSame($ownerId, $pr->head()->repo()->owner()->id());
+        static::assertSame($ownerLogin, $pr->head()->repo()->owner()->login());
+        static::assertSame($ownerHtmlUrl, $pr->head()->repo()->owner()->htmlUrl());
+        static::assertSame($userId, $pr->user()->id());
+        static::assertSame($userLogin, $pr->user()->login());
+        static::assertSame($userHtmlUrl, $pr->user()->htmlUrl());
+        static::assertTrue($pr->isMergeable());
+        static::assertSame($body, $pr->body());
+        static::assertSame($htmlUrl, $pr->htmlUrl());
+        static::assertTrue($pr->hasLabels());
 
         $label = $pr->labels()[0];
-        self::assertSame($labelName, $label->name());
-        self::assertSame($labelColor, $label->color()->toString());
+        static::assertSame($labelName, $label->name());
+        static::assertSame($labelColor, $label->color()->toString());
     }
 
     /**
@@ -319,7 +319,7 @@ final class PullRequestTest extends TestCase
 
         $pr = PullRequest::fromResponse($response);
 
-        self::assertTrue($pr->updatedWithinTheLast60Seconds());
+        static::assertTrue($pr->updatedWithinTheLast60Seconds());
     }
 
     /**
@@ -338,7 +338,7 @@ final class PullRequestTest extends TestCase
 
         $pr = PullRequest::fromResponse($response);
 
-        self::assertFalse($pr->updatedWithinTheLast60Seconds());
+        static::assertFalse($pr->updatedWithinTheLast60Seconds());
     }
 
     /**
@@ -354,7 +354,7 @@ final class PullRequestTest extends TestCase
 
         $pr = PullRequest::fromResponse($response);
 
-        self::assertSame(
+        static::assertSame(
             $expected->toString(),
             $pr->stability()->toString()
         );
@@ -447,11 +447,11 @@ BODY,
 
         $changelog = $pr->changelog();
 
-        self::assertArrayHasKey(
+        static::assertArrayHasKey(
             'Changed',
             $changelog
         );
-        self::assertStringContainsString(
+        static::assertStringContainsString(
             $message,
             $changelog['Changed'][0]
         );

--- a/tests/Github/Domain/Value/Release/TagTest.php
+++ b/tests/Github/Domain/Value/Release/TagTest.php
@@ -38,6 +38,6 @@ final class TagTest extends TestCase
     {
         $tag = Tag::fromString('1.1.0');
 
-        self::assertSame('1.1.0', $tag->toString());
+        static::assertSame('1.1.0', $tag->toString());
     }
 }

--- a/tests/Github/Domain/Value/RepositoryTest.php
+++ b/tests/Github/Domain/Value/RepositoryTest.php
@@ -65,8 +65,8 @@ final class RepositoryTest extends TestCase
     {
         $repository = Repository::fromString('sonata-project/SonataAdminBundle');
 
-        self::assertSame('sonata-project', $repository->username());
-        self::assertSame('SonataAdminBundle', $repository->name());
-        self::assertSame('sonata-project/SonataAdminBundle', $repository->toString());
+        static::assertSame('sonata-project', $repository->username());
+        static::assertSame('SonataAdminBundle', $repository->name());
+        static::assertSame('sonata-project/SonataAdminBundle', $repository->toString());
     }
 }

--- a/tests/Github/Domain/Value/Search/QueryTest.php
+++ b/tests/Github/Domain/Value/Search/QueryTest.php
@@ -54,7 +54,7 @@ final class QueryTest extends TestCase
     {
         $query = Query::fromString('abc');
 
-        self::assertSame('abc', $query->toString());
+        static::assertSame('abc', $query->toString());
     }
 
     /**
@@ -99,7 +99,7 @@ CONFIG;
             'SonataCI'
         );
 
-        self::assertSame(
+        static::assertSame(
             'repo:sonata-project/SonataAdminBundle type:pr is:merged base:master merged:>2020-01-01T10:00:00Z -author:SonataCI',
             $query->toString()
         );

--- a/tests/Github/Domain/Value/ShaTest.php
+++ b/tests/Github/Domain/Value/ShaTest.php
@@ -43,6 +43,6 @@ final class ShaTest extends TestCase
 
         $sha = Sha::fromString($value);
 
-        self::assertSame($value, $sha->toString());
+        static::assertSame($value, $sha->toString());
     }
 }

--- a/tests/Github/Domain/Value/StatusTest.php
+++ b/tests/Github/Domain/Value/StatusTest.php
@@ -135,7 +135,7 @@ final class StatusTest extends TestCase
             'state' => $state,
         ]);
 
-        self::assertSame(
+        static::assertSame(
             $state,
             Status::fromResponse($response)->state()
         );
@@ -159,7 +159,7 @@ final class StatusTest extends TestCase
     {
         $response = Github\Response\StatusFactory::create();
 
-        self::assertSame(
+        static::assertSame(
             $response['description'],
             Status::fromResponse($response)->description()
         );
@@ -172,7 +172,7 @@ final class StatusTest extends TestCase
     {
         $response = Github\Response\StatusFactory::create();
 
-        self::assertSame(
+        static::assertSame(
             $response['target_url'],
             Status::fromResponse($response)->targetUrl()
         );

--- a/tests/Github/Domain/Value/UrlTest.php
+++ b/tests/Github/Domain/Value/UrlTest.php
@@ -53,6 +53,6 @@ final class UrlTest extends TestCase
 
         $url = Url::fromString($value);
 
-        self::assertSame($value, $url->toString());
+        static::assertSame($value, $url->toString());
     }
 }

--- a/tests/Github/Domain/Value/UserTest.php
+++ b/tests/Github/Domain/Value/UserTest.php
@@ -75,7 +75,7 @@ final class UserTest extends TestCase
 
         $user = User::fromResponse($response);
 
-        self::assertSame(
+        static::assertSame(
             $value,
             $user->id()
         );
@@ -122,7 +122,7 @@ final class UserTest extends TestCase
 
         $user = User::fromResponse($response);
 
-        self::assertSame(
+        static::assertSame(
             $value,
             $user->login()
         );
@@ -139,7 +139,7 @@ final class UserTest extends TestCase
 
         $user = User::fromResponse($response);
 
-        self::assertSame(
+        static::assertSame(
             '@'.$value,
             $user->handle()
         );
@@ -186,7 +186,7 @@ final class UserTest extends TestCase
 
         $user = User::fromResponse($response);
 
-        self::assertSame(
+        static::assertSame(
             $value,
             $user->htmlUrl()
         );

--- a/tests/Github/Exception/LatestReleaseNotFoundTest.php
+++ b/tests/Github/Exception/LatestReleaseNotFoundTest.php
@@ -38,11 +38,11 @@ final class LatestReleaseNotFoundTest extends TestCase
 
         $latestReleaseNotFound = LatestReleaseNotFound::forRepository($repository);
 
-        self::assertInstanceOf(
+        static::assertInstanceOf(
             \RuntimeException::class,
             $latestReleaseNotFound
         );
-        self::assertSame(
+        static::assertSame(
             sprintf(
                 'Could not find latest Release for "%s".',
                 $repository->toString()

--- a/tests/Twig/Extension/GithubSponsorsExtensionTest.php
+++ b/tests/Twig/Extension/GithubSponsorsExtensionTest.php
@@ -47,7 +47,7 @@ final class GithubSponsorsExtensionTest extends TestCase
         $package->fromArray(['repository' => 'https://github.com/sonata-project/SonataAdminBundle']);
 
         $repo = $this->createMock(Repo::class);
-        $repo->expects(self::once())
+        $repo->expects(static::once())
             ->method('contributors')
             ->with('sonata-project', 'SonataAdminBundle')
             ->willReturn([
@@ -58,12 +58,12 @@ final class GithubSponsorsExtensionTest extends TestCase
             ]);
 
         $this->github
-            ->expects(self::once())
+            ->expects(static::once())
             ->method('__call')
             ->with('repo')
             ->willReturn($repo);
 
-        self::assertSame(
+        static::assertSame(
             ['OskarStark', 'VincentLanglet', 'greg0ire'],
             $this->githubSponsorsExtension->listSponsorisable(Repository::fromPackage($package)),
         );
@@ -78,7 +78,7 @@ final class GithubSponsorsExtensionTest extends TestCase
         $package->fromArray(['repository' => 'https://github.com/sonata-project/SonataAdminBundle']);
 
         $repo = $this->createMock(Repo::class);
-        $repo->expects(self::once())
+        $repo->expects(static::once())
             ->method('contributors')
             ->with('sonata-project', 'SonataAdminBundle')
             ->willReturn([
@@ -91,12 +91,12 @@ final class GithubSponsorsExtensionTest extends TestCase
             ]);
 
         $this->github
-            ->expects(self::once())
+            ->expects(static::once())
             ->method('__call')
             ->with('repo')
             ->willReturn($repo);
 
-        self::assertSame(
+        static::assertSame(
             ['OskarStark', 'VincentLanglet', 'core23', 'wbloszyk'],
             $this->githubSponsorsExtension->listSponsorisable(Repository::fromPackage($package)),
         );


### PR DESCRIPTION
This will change all the PHPUnit dynamic calls to static calls and help with the strict rules phpstan plugin

Or do we want to do this when the time comes for each package?