### PR TITLE
Try with Symfony 5.4

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -7,13 +7,13 @@ admin-bundle:
             php: ['7.3', '7.4', '8.0']
             frontend: true
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/block-bundle: ['4.*']
         4.x:
             php: ['7.3', '7.4', '8.0']
             frontend: true
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/block-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
@@ -112,11 +112,11 @@ block-bundle:
         master:
             php: ['7.3', '7.4', '8.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         4.x:
             php: ['7.3', '7.4', '8.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             variants:
@@ -153,7 +153,7 @@ classification-bundle:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb-1.9.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/admin-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
@@ -228,13 +228,13 @@ doctrine-mongodb-admin-bundle:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb-1.9.0', 'zip']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/admin-bundle: ['4.*']
         4.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb-1.9.0', 'zip']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/admin-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
@@ -253,13 +253,13 @@ doctrine-orm-admin-bundle:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['zip']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/admin-bundle: ['4.*']
         4.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['zip']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/admin-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
@@ -323,12 +323,12 @@ exporter:
             php: ['7.3', '7.4']
             php_extensions: ['mongodb-1.9.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         2.x:
             php: ['7.3', '7.4']
             php_extensions: ['mongodb-1.9.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
 
 formatter-bundle:
     phpstan: true
@@ -351,11 +351,11 @@ form-extensions:
         master:
             php: ['7.3', '7.4', '8.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         1.x:
             php: ['7.3', '7.4', '8.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
 
 google-authenticator:
     excluded_files:
@@ -373,12 +373,12 @@ intl-bundle:
             php: ['7.3', '7.4', '8.0']
             target_php: '7.4'
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         2.x:
             php: ['7.3', '7.4', '8.0']
             target_php: '7.4'
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/user-bundle: ['4.*']
 
 media-bundle:
@@ -392,7 +392,7 @@ media-bundle:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb-1.9.0', 'soap', 'gd']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
                 sonata-project/admin-bundle: ['4.*']
                 imagine/imagine: ['1.*']
         3.x:
@@ -429,7 +429,7 @@ notification-bundle:
         master:
             php: ['7.3', '7.4', '8.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             variants:
@@ -471,7 +471,7 @@ seo-bundle:
         master:
             php: ['7.3', '7.4', '8.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         2.x:
             php: ['7.3', '7.4', '8.0']
             variants:
@@ -517,11 +517,11 @@ twig-extensions:
         master:
             php: ['7.3', '7.4', '8.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         1.x:
             php: ['7.3', '7.4', '8.0']
             variants:
-                symfony/symfony: ['4.4.*', '5.3.*']
+                symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
 
 user-bundle:
     phpstan: true

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -99,6 +99,9 @@ jobs:
               if: matrix.variant != 'normal' && !startsWith(matrix.variant, 'symfony/symfony')
               {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
 
+            - name: Allow unstable dependencies
+              run: composer config minimum-stability dev
+
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}
             - name: Set COMPOSER_ROOT_VERSION environment variable

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -188,6 +188,9 @@ jobs:
               if: matrix.variant != 'normal' && !startsWith(matrix.variant, 'symfony/symfony')
               run: composer require ${{ matrix.variant }} --no-update
 
+            - name: Allow unstable dependencies
+              run: composer config minimum-stability dev
+
             - name: "Install Composer dependencies (${{ matrix.dependencies }})"
               uses: "ramsey/composer-install@v1"
               with:


### PR DESCRIPTION
We need to add test for Symfony 5.4 and start fixing deprecations. Why? Because Symfony will add a lot of types on 6.0 and we can detect those on Symfony 5.4 already.

They said we can report the types that can't be added without BC break post them here: https://github.com/symfony/symfony/issues/43021

There is also a tool that can be used to automatically add types and detect incompatibilities: https://wouterj.nl/2021/09/symfony-6-native-typing

IMO we should slow down a bit and ensure we are fully compatible with Sf 5.4 and 6.0 because we have a good change to be compatible right away and if not maybe symfony guys can help us. If we delay this a lot, we would end up in the same situation like with Symfony 5.

wdyt?