### PR TITLE
SeoBundle: Rename next major branch

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -468,7 +468,7 @@ seo-bundle:
     phpstan: true
     psalm: true
     branches:
-        master:
+        3.x:
             php: ['7.3', '7.4', '8.0']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']


### PR DESCRIPTION
Rename `master` branch to `3.x` version branch, so we can rid of the unspecific branch.

Are you okay with this @sonata-project/contributors ?

We can also remove the `branch-alias` after renaming the branch: https://github.com/sonata-project/SonataSeoBundle/blob/master/composer.json#L59

## Todo

- [ ] Merge this
- [ ] Rename branch
- [ ] Remove branch alias
- [ ] Communicate changes