### PR TITLE
SeoBundle: Remove support for PHP 7.3

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -469,7 +469,7 @@ seo-bundle:
     psalm: true
     branches:
         3.x:
-            php: ['7.3', '7.4', '8.0']
+            php: ['7.4', '8.0']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
         2.x:


### PR DESCRIPTION
Supports: https://github.com/sonata-project/SonataSeoBundle/pull/585