### PR TITLE
Remove useless spaces

### DIFF
--- a/templates/project/README.md.twig
+++ b/templates/project/README.md.twig
@@ -27,7 +27,7 @@ Branch | Github Actions | Code Coverage |
 ------ | -------------- | ------------- |
 {% endif %}
 {% if project.stableBranch is not null %}
-{{ project.stableBranch.name }}    | [![Test][test_stable_badge]][test_stable_link]     | [![Coverage Status][coverage_stable_badge]][coverage_stable_link]     |{% if project.hasDocumentation %} [![Documentation Status][documentation_stable_badge]][documentation_stable_link]     |{% endif %}
+{{ project.stableBranch.name }} | [![Test][test_stable_badge]][test_stable_link] | [![Coverage Status][coverage_stable_badge]][coverage_stable_link] |{% if project.hasDocumentation %} [![Documentation Status][documentation_stable_badge]][documentation_stable_link]     |{% endif %}
 
 {% endif %}
 {{ project.unstableBranch.name }} | [![Test][test_unstable_badge]][test_unstable_link] | [![Coverage Status][coverage_unstable_badge]][coverage_unstable_link] |{% if project.hasDocumentation %} [![Documentation Status][documentation_unstable_badge]][documentation_unstable_link] |{% endif %}


### PR DESCRIPTION
Since `master` was renamed, the unstable branch line isn't aligned anymore.
https://raw.githubusercontent.com/sonata-project/sonata-doctrine-extensions/1.x/README.md

We have two choices:
- Adding 3 space to align the columns
- Stop trying to align the columns

Since we will have issue with `9.x` vs `10.x` and others columns are not aligned, I think we should just stop trying to align the columns.
