### PR TITLE
admin-bundle: Allow to test php 8.1

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -4,17 +4,15 @@ admin-bundle:
     documentation_badge_slug: sonata-project-sonataadminbundle
     branches:
         5.x:
-            php: ['7.3', '7.4', '8.0']
+            php: ['7.3', '7.4', '8.0', '8.1']
             frontend: true
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
-                sonata-project/block-bundle: ['4.*']
         4.x:
-            php: ['7.3', '7.4', '8.0']
+            php: ['7.3', '7.4', '8.0', '8.1']
             frontend: true
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
-                sonata-project/block-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             custom_gitignore_part: |


### PR DESCRIPTION
It also removes block-bundle 4 variants since it is the only version supported.

POC: https://github.com/sonata-project/SonataAdminBundle/pull/7528