### PR TITLE
Remove unnecessary variants

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -131,13 +131,11 @@ classification-bundle:
             php_extensions: ['mongodb-1.9.0']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
-                sonata-project/admin-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb-1.9.0']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['3.*']
 
 datagrid-bundle:
     branches:
@@ -170,19 +168,16 @@ doctrine-mongodb-admin-bundle:
             php_extensions: ['mongodb-1.9.0', 'zip']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
-                sonata-project/admin-bundle: ['4.*']
         4.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb-1.9.0', 'zip']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
-                sonata-project/admin-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb-1.9.0', 'zip']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['3.*']
 
 doctrine-orm-admin-bundle:
     panther: true
@@ -193,19 +188,16 @@ doctrine-orm-admin-bundle:
             php_extensions: ['zip']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*', '6.0.*']
-                sonata-project/admin-bundle: ['4.*']
         4.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['zip']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*', '6.0.*']
-                sonata-project/admin-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['zip']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['3.*']
 
 entity-audit-bundle:
     excluded_files:
@@ -299,22 +291,16 @@ media-bundle:
             php_extensions: ['mongodb-1.9.0', 'gd']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
-                sonata-project/admin-bundle: ['4.*']
-                imagine/imagine: ['1.*']
         4.x:
             php: ['7.4', '8.0']
             php_extensions: ['mongodb-1.9.0', 'gd']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*']
-                sonata-project/admin-bundle: ['4.*']
-                imagine/imagine: ['1.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb-1.9.0', 'soap', 'gd']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['3.*']
-                imagine/imagine: ['1.*']
 
 news-bundle:
     custom_doctor_rst_whitelist_part:
@@ -325,13 +311,11 @@ news-bundle:
             php_extensions: ['zip']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['4.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['zip']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['3.*']
 
 notification-bundle:
     custom_doctor_rst_whitelist_part:
@@ -356,13 +340,11 @@ page-bundle:
             php: ['7.4', '8.0']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['3.*']
                 sonata-project/block-bundle: ['3.*']
         3.x:
             php: ['7.3', '7.4', '8.0']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['3.*']
                 sonata-project/block-bundle: ['3.*']
 
 sandbox:
@@ -392,7 +374,6 @@ seo-bundle:
             variants:
                 symfony/symfony: ['4.4.*']
                 sonata-project/block-bundle: ['3.*']
-                sonata-project/admin-bundle: ['3.*']
 
 translation-bundle:
     branches:
@@ -401,13 +382,11 @@ translation-bundle:
             php_extensions: ['pdo_sqlite']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*', '6.0.*']
-                sonata-project/admin-bundle: ['4.*']
         2.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['pdo_sqlite']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/admin-bundle: ['3.*']
 
 twig-extensions:
     documentation_badge_slug: sonata-project-twig-extensions
@@ -429,11 +408,7 @@ user-bundle:
             php: ['7.3', '7.4', '8.0']
             variants:
                 symfony/symfony: ['4.4.*']
-                friendsofsymfony/user-bundle: ['2.*']
-                sonata-project/admin-bundle: ['3.*']
         4.x:
             php: ['7.3', '7.4', '8.0']
             variants:
                 symfony/symfony: ['4.4.*']
-                friendsofsymfony/user-bundle: ['2.*']
-                sonata-project/admin-bundle: ['3.*']


### PR DESCRIPTION
These packages require `sonata-project/admin-bundle: ^4.0` in those branches, so I think there is no need for these variants, for example for the ORM:

`sonata-project/admin-bundle: ['4.*']` variant: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/runs/3919800612?check_suite_focus=true
highest dependencies job: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/runs/3919800560?check_suite_focus=true

**update**: since we are supporting just one version of `sonata-project/admin-bundle` per branch I guess we can remove any `sonata-project/admin-bundle` variant 🤔 