### PR TITLE
Allow @psalm-suppress in phpdoc outside structural elements

### DIFF
--- a/templates/project/.php-cs-fixer.dist.php
+++ b/templates/project/.php-cs-fixer.dist.php
@@ -48,6 +48,7 @@ $rules = [
     'php_unit_test_annotation' => false,
     'php_unit_test_case_static_method_calls' => true,
     'phpdoc_order' => true,
+    'phpdoc_to_comment' => ['ignored_tags' => ['psalm-suppress']],
     'single_line_throw' => false,
     'static_lambda' => true,
     'strict_comparison' => true,


### PR DESCRIPTION
Otherwise it gets converted to normal php comments and not parsed by Psalm.