### PR TITLE
Reduce list of incompatible deps with Symfony 6

### DIFF
--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -91,7 +91,7 @@ jobs:
 {# Remove when when all dev dependencies are compatible with Symfony 6 #}
             - name: Remove dev dependencies not compatible with Symfony 6
               if: matrix.symfony-require == '6.0.*'
-              run: composer remove vimeo/psalm psalm/plugin-phpunit psalm/plugin-symfony weirdan/doctrine-psalm-plugin symfony/maker-bundle --dev --no-update --no-interaction
+              run: composer remove psalm/plugin-symfony symfony/maker-bundle --dev --no-update --no-interaction
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}
 {% if project.repository.name == 'SonataBlockBundle' and branch.name == '3.x' %}

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -185,7 +185,7 @@ jobs:
 
             - name: Remove dev dependencies not compatible with Symfony 6
               if: matrix.symfony-require == '6.0.*'
-              run: composer remove vimeo/psalm psalm/plugin-phpunit psalm/plugin-symfony weirdan/doctrine-psalm-plugin symfony/maker-bundle --dev --no-update --no-interaction
+              run: composer remove psalm/plugin-symfony symfony/maker-bundle --dev --no-update --no-interaction
 
             - name: Install Composer dependencies (${{ matrix.dependencies }})
               uses: ramsey/composer-install@v1


### PR DESCRIPTION
Psalm and most of its plugins are already compatible with Symfony 6, the only missing one is the psalm-symfony plugin.