### PR TITLE
Do not target_php for doctrine extensions

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -152,11 +152,9 @@ doctrine-extensions:
         2.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb']
-            target_php: '7.4'
         1.x:
             php: ['7.3', '7.4', '8.0']
             php_extensions: ['mongodb']
-            target_php: '7.4'
 
 doctrine-mongodb-admin-bundle:
     panther: true


### PR DESCRIPTION
This is another step to add php 8.1 to all repositories

https://github.com/sonata-project/sonata-doctrine-extensions/pull/374