### PR TITLE
Remove Licence from excluded files

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -195,7 +195,6 @@ doctrine-orm-admin-bundle:
 
 entity-audit-bundle:
     excluded_files:
-        - LICENSE
         - README.md
     has_documentation: false
     branches:


### PR DESCRIPTION
I asked beberlei, and he's ok with the change of the Licence of the EntityAuditBundle from GNU to MIT.

We should also have the agreement of main contributors.
https://github.com/sonata-project/EntityAuditBundle/graphs/contributors

@bendavies @andrewtch are you also ok with this change ?