### PR TITLE
Only allow dev dependencies for SF6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "sonata-project/dev-kit",
-    "type": "project",
     "description": "Sonata project tools kit.",
     "license": "MIT",
+    "type": "project",
     "authors": [
         {
             "name": "Sullivan SENECHAL",
@@ -44,18 +44,6 @@
         "twig/twig": "^2.12 || ^3.0",
         "webmozart/assert": "^1.9"
     },
-    "replace": {
-        "paragonie/random_compat": "2.*",
-        "symfony/polyfill-ctype": "*",
-        "symfony/polyfill-iconv": "*",
-        "symfony/polyfill-php56": "*",
-        "symfony/polyfill-php70": "*",
-        "symfony/polyfill-php71": "*",
-        "symfony/polyfill-php72": "*"
-    },
-    "conflict": {
-        "symfony/symfony": "*"
-    },
     "require-dev": {
         "ergebnis/test-util": "^1.2",
         "phpstan/extension-installer": "^1.0",
@@ -73,6 +61,28 @@
         "symfony/web-profiler-bundle": "^5.3",
         "vimeo/psalm": "^4.9.2"
     },
+    "replace": {
+        "paragonie/random_compat": "2.*",
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-php56": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php72": "*"
+    },
+    "conflict": {
+        "symfony/symfony": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\": "tests"
+        }
+    },
     "config": {
         "platform": {
             "php": "7.4"
@@ -86,16 +96,6 @@
         "symfony": {
             "allow-contrib": true,
             "require": "5.3.*"
-        }
-    },
-    "autoload": {
-        "psr-4": {
-            "App\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "App\\Tests\\": "tests"
         }
     },
     "scripts": {

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -86,6 +86,7 @@ jobs:
               {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
 
             - name: Allow unstable dependencies
+              if: matrix.symfony-require == '6.0.*'
               run: composer config minimum-stability dev
 
 {# Remove when removing 3.x for the managed branches of block-bundle #}

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -181,6 +181,7 @@ jobs:
               run: composer require ${{ matrix.variant }} --no-update
 
             - name: Allow unstable dependencies
+              if: matrix.symfony-require == '6.0.*'
               run: composer config minimum-stability dev
 
             - name: Install Composer dependencies (${{ matrix.dependencies }})


### PR DESCRIPTION
We should use stable dependencies for build as much as possible.