### PR TITLE
Stick Phpcs to 3.4

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
               with:
                   php-version: '8.0'
                   coverage: none
-                  tools: composer:v2, php-cs-fixer:3
+                  tools: composer:v2, php-cs-fixer:3.4
               env:
                   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/templates/project/.github/workflows/lint.yaml.twig
+++ b/templates/project/.github/workflows/lint.yaml.twig
@@ -29,7 +29,7 @@ jobs:
               with:
                   php-version: '{{ branch.targetPhpVersion.toString }}'
                   coverage: none
-                  tools: composer:v2, php-cs-fixer:3
+                  tools: composer:v2, php-cs-fixer:3.4
               env:
                   {% verbatim %}COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}{% endverbatim %}
 


### PR DESCRIPTION
Phpcs 3.5 has a bug changing all the `&` to `|` in the phpdoc. So all our ci are failing