### PR TITLE
Disallow unstable deps

### DIFF
--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -87,10 +87,6 @@ jobs:
               if: matrix.variant != 'normal' && !startsWith(matrix.variant, 'symfony/symfony')
               {% verbatim %}run: composer require ${{ matrix.variant }} --no-update{% endverbatim %}
 
-            - name: Allow unstable dependencies
-              if: matrix.symfony-require == '6.0.*'
-              run: composer config minimum-stability dev
-
             - name: Install Composer dependencies ({% verbatim %}${{ matrix.dependencies }}{% endverbatim %})
               uses: ramsey/composer-install@v2
               with:

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -182,10 +182,6 @@ jobs:
               if: matrix.variant != 'normal' && !startsWith(matrix.variant, 'symfony/symfony')
               run: composer require ${{ matrix.variant }} --no-update
 
-            - name: Allow unstable dependencies
-              if: matrix.symfony-require == '6.0.*'
-              run: composer config minimum-stability dev
-
             - name: Install Composer dependencies (${{ matrix.dependencies }})
               uses: ramsey/composer-install@v2
               with:


### PR DESCRIPTION
To finish: https://github.com/sonata-project/dev-kit/issues/1675

There is SonataPageBundle missing support, but that should be tackled specifically at that repository, because it does not even support Sonata 4, Symfony 5.