### PR TITLE
Avoid psalm error

### DIFF
--- a/templates/project/tests/bootstrap.php.twig
+++ b/templates/project/tests/bootstrap.php.twig
@@ -31,5 +31,10 @@ if (class_exists(Deprecation::class)) {
 }
 
 if (file_exists($file = __DIR__.'/custom_bootstrap.php')) {
+    /**
+     * @psalm-suppress MissingFile,UnusedPsalmSuppress
+     *
+     * @see https://github.com/vimeo/psalm/issues/3886
+     */
     require_once $file;
 }


### PR DESCRIPTION
Psalm is now reporting `MissingFile` error when there is no file, so we need a psalm suppress.
I also added `UnusedPsalmSuppress`, in case the missingFile is not thrown because the file exists.