### PR TITLE
Remove 4.x of SonataUserBundle

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -309,9 +309,6 @@ twig-extensions:
 
 user-bundle:
     phpunit_extensions: ['doctrine_test']
-    custom_doctor_rst_whitelist_part:
-        "    - 'resource: \"@NelmioApiDocBundle/Resources/config/routing.yml\"'"
-    has_test_kernel: false
     branches:
         6.x:
             php: ['7.4', '8.0', '8.1']
@@ -321,7 +318,4 @@ user-bundle:
             php: ['7.4', '8.0', '8.1']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*', '6.0.*']
-        4.x:
-            php: ['7.3', '7.4', '8.0']
-            variants:
-                symfony/symfony: ['4.4.*']
+

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -318,4 +318,3 @@ user-bundle:
             php: ['7.4', '8.0', '8.1']
             variants:
                 symfony/symfony: ['4.4.*', '5.3.*', '5.4.*', '6.0.*']
-


### PR DESCRIPTION
There isnt a lot of activity on the 4.x branch. If we need to do some patch release we can generate changelog manually