### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/dispatch-files-branches.yaml
+++ b/.github/workflows/dispatch-files-branches.yaml
@@ -13,6 +13,9 @@ on:
 env:
     REQUIRED_PHP_EXTENSIONS: redis
 
+permissions:
+    contents: read
+
 jobs:
     dispatch:
         name: PHP ${{ matrix.php-version }}

--- a/.github/workflows/dispatch-labels-hooks-topics-settings.yaml
+++ b/.github/workflows/dispatch-labels-hooks-topics-settings.yaml
@@ -9,6 +9,9 @@ on:
 env:
     REQUIRED_PHP_EXTENSIONS: redis
 
+permissions:
+    contents: read
+
 jobs:
     dispatch:
         name: PHP ${{ matrix.php-version }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -10,6 +10,9 @@ on:
             - master
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     build:
         name: Sphinx build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,9 @@ on:
             - master
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     php-cs-fixer:
         name: PHP-CS-Fixer

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -6,6 +6,9 @@ on:
             - master
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     phpstan:
         name: PHPStan

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ on:
 env:
     REQUIRED_PHP_EXTENSIONS: redis
 
+permissions:
+    contents: read
+
 jobs:
     test:
         name: PHP ${{ matrix.php-version }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
