### PR TITLE
Do not require changelog for majors

### DIFF
--- a/src/Github/Domain/Value/PullRequest.php
+++ b/src/Github/Domain/Value/PullRequest.php
@@ -252,7 +252,8 @@ final class PullRequest
 
     public function needsChangelog(): bool
     {
-        return $this->stability()->notEquals(Stability::pedantic());
+        return $this->stability()->equals(Stability::minor())
+            || $this->stability()->equals(Stability::patch());
     }
 
     public function hasChangelog(): bool


### PR DESCRIPTION
PR with a `major` label does not always require a changelog because there are upgrade note.
The best example are the "Solve NEXT_MAJOR comments" PRs.

This would allow to release https://master-7rqtwti-ptm4dx6rjpjko.eu-5.platformsh.site/next-release/doctrine-extensions/2.x for instance.