### PR TITLE
Remove useless variant

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -173,12 +173,10 @@ page-bundle:
             php: ['7.4', '8.0']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/block-bundle: ['3.*']
         3.x:
             php: ['7.4', '8.0']
             variants:
                 symfony/symfony: ['4.4.*']
-                sonata-project/block-bundle: ['3.*']
 
 seo-bundle:
     has_test_kernel: false


### PR DESCRIPTION
Those variant are not needed.

BlockBundle is a dependency of PageBundle and there is only one version supported.
This will unblock the bump of blockBundle to v4 on PageBundle 4.