### PR TITLE
Make check-files work again

### DIFF
--- a/templates/project/.github/workflows/frontend.yaml.twig
+++ b/templates/project/.github/workflows/frontend.yaml.twig
@@ -48,4 +48,4 @@ jobs:
               run: npx encore production
 
             - name: Check if the compilation is up to date
-              run: git diff --no-patch --exit-code src/**/Resources/public
+              run: git diff --no-patch --exit-code


### PR DESCRIPTION
This step is suposed to trigger a failure if generated assets by Github Actions are different from the ones provided by the user.