### PR TITLE
Add `target_php` to all packages

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -3,11 +3,13 @@ admin-bundle:
     branches:
         5.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             frontend: true
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             frontend: true
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
@@ -19,10 +21,12 @@ block-bundle:
     branches:
         5.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
 
@@ -30,11 +34,13 @@ classification-bundle:
     branches:
         5.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
@@ -45,20 +51,24 @@ doctrine-extensions:
     branches:
         3.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb']
         2.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb']
 
 doctrine-mongodb-admin-bundle:
     branches:
         5.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
@@ -68,10 +78,12 @@ doctrine-orm-admin-bundle:
     branches:
         5.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
 
@@ -83,10 +95,12 @@ entity-audit-bundle:
     branches:
         2.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         1.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
 
@@ -96,11 +110,13 @@ exporter:
     branches:
         4.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
         3.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
@@ -109,10 +125,12 @@ formatter-bundle:
     branches:
         6.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         5.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
 
@@ -121,11 +139,13 @@ form-extensions:
     branches:
         2.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
         1.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             frontend: true
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
@@ -135,10 +155,12 @@ intl-bundle:
     branches:
         4.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
         3.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
 
@@ -147,11 +169,13 @@ media-bundle:
     branches:
         5.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb', 'gd']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             php_extensions: ['mongodb', 'gd']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
@@ -162,11 +186,13 @@ page-bundle:
     branches:
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             frontend: true
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         3.x:
             php: ['7.4', '8.0']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*']
 
@@ -175,10 +201,12 @@ seo-bundle:
     branches:
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         3.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
 
@@ -186,10 +214,12 @@ translation-bundle:
     branches:
         4.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         3.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
 
@@ -198,10 +228,12 @@ twig-extensions:
     branches:
         3.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
         2.x:
             php: ['8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
 
@@ -209,9 +241,11 @@ user-bundle:
     branches:
         6.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         5.x:
             php: ['7.4', '8.0', '8.1', '8.2']
+            target_php: '8.1'
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']


### PR DESCRIPTION
Adding 8.2 at the end of `php` key to all packages (https://github.com/sonata-project/dev-kit/pull/2214) has made dev-kit PRs fail because it uses the last PHP version specified there to execute [other jobs](https://github.com/sonata-project/SonataAdminBundle/pull/7957/files):

https://github.com/sonata-project/dev-kit/blob/3d7c2f22017d3887cd041440cce6e598ab7d5981/src/Domain/Value/Branch.php#L75

We can solve this by specifying `target_php` key until PHP 8.2 is released as stable and supported by the tools:

https://github.com/sonata-project/dev-kit/blob/3d7c2f22017d3887cd041440cce6e598ab7d5981/src/Domain/Value/Branch.php#L102-L105

