### PR TITLE
Do not test with PHP 8.2 packages using mongodb-odm

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -33,14 +33,12 @@ block-bundle:
 classification-bundle:
     branches:
         5.x:
-            php: ['7.4', '8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['7.4', '8.0', '8.1']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         4.x:
-            php: ['7.4', '8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['7.4', '8.0', '8.1']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
@@ -50,25 +48,21 @@ doctrine-extensions:
     has_test_kernel: false
     branches:
         3.x:
-            php: ['8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['8.0', '8.1']
             php_extensions: ['mongodb']
         2.x:
-            php: ['8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['8.0', '8.1']
             php_extensions: ['mongodb']
 
 doctrine-mongodb-admin-bundle:
     branches:
         5.x:
-            php: ['7.4', '8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['7.4', '8.0', '8.1']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         4.x:
-            php: ['7.4', '8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['7.4', '8.0', '8.1']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
@@ -109,14 +103,12 @@ exporter:
     has_test_kernel: false
     branches:
         4.x:
-            php: ['8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['8.0', '8.1']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
         3.x:
-            php: ['8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['8.0', '8.1']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.0.*', '6.1.*']
@@ -168,14 +160,12 @@ media-bundle:
     documentation_badge_slug: sonata-project-sonatamediabundle
     branches:
         5.x:
-            php: ['7.4', '8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['7.4', '8.0', '8.1']
             php_extensions: ['mongodb', 'gd']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         4.x:
-            php: ['7.4', '8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['7.4', '8.0', '8.1']
             php_extensions: ['mongodb', 'gd']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
@@ -240,12 +230,12 @@ twig-extensions:
 user-bundle:
     branches:
         6.x:
-            php: ['7.4', '8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['7.4', '8.0', '8.1']
+            php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']
         5.x:
-            php: ['7.4', '8.0', '8.1', '8.2']
-            target_php: '8.1'
+            php: ['7.4', '8.0', '8.1']
+            php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*']


### PR DESCRIPTION
We cannot test yet with php 8.2 packages requiring `doctrine/mongodb-odm` because

[`doctrine/mongodb-odm` requires `friendsofphp/proxy-manager-lts`](https://github.com/doctrine/mongodb-odm/blob/f5c16795858ab537922ead80eb122927f6d78686/composer.json#L33)
[`friendsofphp/proxy-manager-lts` requires `laminas/laminas-code`](https://github.com/FriendsOfPHP/proxy-manager-lts/blob/88354616f4cf4f6620910fd035e282173ba453e8/composer.json#L30)

and `laminas/laminas-code` [is not yet compatible with php 8.2](https://github.com/laminas/laminas-code/blob/c129dfc341b8ac3c86ef70d7888c6dc3899e5d8b/composer.json#L12).

Failing job example:

https://github.com/sonata-project/SonataClassificationBundle/actions/runs/3354777254/jobs/5558559363