### PR TITLE
Ensure page-bundle 4 works with block-bundle 5

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -162,11 +162,13 @@ page-bundle:
             frontend: true
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.2.*']
+                sonata-project/block-bundle: ['5.x-dev as 4.999']
         4.x:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
                 symfony/symfony: ['4.4.*', '5.4.*', '6.2.*']
+                sonata-project/block-bundle: ['5.x-dev as 4.999']
 
 seo-bundle:
     has_test_kernel: false


### PR DESCRIPTION
Since it is the bundle who uses most of the features of blocks, I think we should add this.