### PR TITLE
Drop sf 4.4 disable form abstract phpstan

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -5,12 +5,12 @@ admin-bundle:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
-                symfony/symfony: ['4.4.*', '5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*']
         4.x:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
-                symfony/symfony: ['4.4.*', '5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*']
                 sonata-project/block-bundle: ['5.x-dev as 4.999']
                 sonata-project/form-extensions: ['2.x-dev as 1.999']
 

--- a/templates/project/phpstan.neon.dist.twig
+++ b/templates/project/phpstan.neon.dist.twig
@@ -35,3 +35,11 @@ parameters:
     checkMissingVarTagTypehint: true
     checkMissingTypehints: true
     checkUninitializedProperties: true
+{% if has_dependency(project_dir, 'phpstan/phpstan-symfony') %}
+    featureToggles:
+        skipCheckGenericClasses:
+            - Symfony\Component\Form\AbstractType
+            - Symfony\Component\Form\FormInterface
+            - Symfony\Component\Form\FormTypeExtensionInterface
+            - Symfony\Component\Form\FormTypeInterface
+{% endif %}


### PR DESCRIPTION
Doing this avoids all the errors on the admin-bundle so it should work on all bundles the same.

When we want to deal with all the abstract things from the forms, we can remove those lines.

https://github.com/sonata-project/SonataAdminBundle/pull/8044