### PR TITLE
Use dev-kit label to identify dev-kit PRs

### DIFF
--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -49,3 +49,5 @@ labels:
       color: '0366d6'
     - name: 'automerge'
       color: '6dfd06'
+    - name: 'dev-kit'
+      color: '930bcf'

--- a/src/Action/DetermineNextRelease.php
+++ b/src/Action/DetermineNextRelease.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace App\Action;
 
 use App\Action\Exception\NoPullRequestsMergedSinceLastRelease;
-use App\Command\AbstractCommand;
 use App\Domain\Value\Branch;
 use App\Domain\Value\NextRelease;
 use App\Domain\Value\Project;
@@ -23,6 +22,7 @@ use App\Github\Api\Checks;
 use App\Github\Api\PullRequests;
 use App\Github\Api\Releases;
 use App\Github\Api\Statuses;
+use App\Github\Domain\Value\Label;
 use App\Github\Domain\Value\Release\Tag;
 use App\Github\Domain\Value\Search\Query;
 use App\Github\Exception\LatestReleaseNotFound;
@@ -67,12 +67,12 @@ final class DetermineNextRelease
         if (null === $releaseDate) {
             $pullRequests = $this->pullRequests->search(
                 $repository,
-                Query::pullRequests($repository, $branch, AbstractCommand::SONATA_CI_BOT)
+                Query::pullRequests($repository, $branch, Label::DevKit())
             );
         } else {
             $pullRequests = $this->pullRequests->search(
                 $repository,
-                Query::pullRequestsSince($repository, $branch, $releaseDate, AbstractCommand::SONATA_CI_BOT)
+                Query::pullRequestsSince($repository, $branch, $releaseDate, Label::DevKit())
             );
         }
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -25,7 +25,6 @@ abstract class AbstractCommand extends Command
 {
     public const GITHUB_USER = 'SonataCI';
     public const GITHUB_EMAIL = 'thomas+ci@sonata-project.org';
-    public const SONATA_CI_BOT = 'SonataCI';
     public const DEPENDABOT_BOT = 'dependabot[bot]';
 
     protected const LABEL_NOTHING_CHANGED = 'Nothing to be changed.';

--- a/src/Command/CommentNonMergeablePullRequestsCommand.php
+++ b/src/Command/CommentNonMergeablePullRequestsCommand.php
@@ -130,10 +130,10 @@ final class CommentNonMergeablePullRequestsCommand extends AbstractNeedApplyComm
                             $message
                         );
 
-                        $this->issues->addLabel(
+                        $this->issues->addLabels(
                             $repository,
                             $pr->issue(),
-                            $label
+                            [$label]
                         );
                     }
 

--- a/src/Command/Dispatcher/DispatchFilesCommand.php
+++ b/src/Command/Dispatcher/DispatchFilesCommand.php
@@ -210,7 +210,10 @@ final class DispatchFilesCommand extends AbstractNeedApplyCommand
                         // Wait 200ms to be sure GitHub API is up to date with new pushed branch/PR.
                         usleep(200000);
 
-                        $this->issues->addLabel($repository, $pullRequest->issue(), Label::AutoMerge());
+                        $this->issues->addLabels($repository, $pullRequest->issue(), [
+                            Label::DevKit(),
+                            Label::AutoMerge(),
+                        ]);
                     }
                 }
             } else {

--- a/src/Domain/Value/NextRelease.php
+++ b/src/Domain/Value/NextRelease.php
@@ -55,15 +55,7 @@ final class NextRelease
 
         $this->combinedStatus = $combinedStatus;
         $this->checkRuns = $checkRuns;
-        $this->pullRequests = array_reduce($pullRequests, static function (array $pullRequests, PullRequest $pullRequest): array {
-            if ($pullRequest->createdAutomatically()) {
-                return $pullRequests;
-            }
-
-            $pullRequests[] = $pullRequest;
-
-            return $pullRequests;
-        }, []);
+        $this->pullRequests = $pullRequests;
 
         $this->nextTag = DetermineNextReleaseVersion::forTagAndPullRequests(
             $currentTag,

--- a/src/Github/Api/Issues.php
+++ b/src/Github/Api/Issues.php
@@ -31,13 +31,19 @@ final class Issues
         $this->github = $github;
     }
 
-    public function addLabel(Repository $repository, Issue $issue, Label $label): void
+    /**
+     * @param array<Label> $labels
+     */
+    public function addLabels(Repository $repository, Issue $issue, array $labels): void
     {
         $this->github->issues()->labels()->add(
             $repository->username(),
             $repository->name(),
             $issue->toInt(),
-            $label->name()
+            array_map(
+                static fn (Label $label): string => $label->name(),
+                $labels
+            )
         );
     }
 

--- a/src/Github/Domain/Value/Label.php
+++ b/src/Github/Domain/Value/Label.php
@@ -73,6 +73,14 @@ final class Label
         );
     }
 
+    public static function DevKit(): self
+    {
+        return self::fromValues(
+            'dev-kit',
+            Color::fromString('930bcf')
+        );
+    }
+
     public static function AutoMerge(): self
     {
         return self::fromValues(

--- a/src/Github/Domain/Value/PullRequest.php
+++ b/src/Github/Domain/Value/PullRequest.php
@@ -13,14 +13,11 @@ declare(strict_types=1);
 
 namespace App\Github\Domain\Value;
 
-use App\Command\AbstractCommand;
 use App\Domain\Value\Stability;
 use App\Domain\Value\TrimmedNonEmptyString;
 use App\Github\Domain\Value\PullRequest\Base;
 use App\Github\Domain\Value\PullRequest\Head;
 use Webmozart\Assert\Assert;
-
-use function Symfony\Component\String\u;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -309,22 +306,5 @@ final class PullRequest
         }
 
         return $changelog;
-    }
-
-    public function createdAutomatically(): bool
-    {
-        if ('Applied fixes from FlintCI' === $this->title
-            && 'soullivaneuh' === $this->user->login()
-        ) {
-            return true;
-        }
-
-        if (u($this->title)->startsWith('DevKit updates for')
-            && AbstractCommand::SONATA_CI_BOT === $this->user->login()
-        ) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/Github/Domain/Value/Search/Query.php
+++ b/src/Github/Domain/Value/Search/Query.php
@@ -59,7 +59,7 @@ final class Query
     {
         return new self(
             sprintf(
-                'repo:%s type:pr is:merged base:%s merged:>%s -author:%s',
+                'repo:%s type:pr is:merged base:%s merged:>%s -label:%s',
                 $repository->toString(),
                 $branch->name(),
                 $date->format('Y-m-d\TH:i:s\Z'), // @todo check if there is a better way to format the datetime like this

--- a/src/Github/Domain/Value/Search/Query.php
+++ b/src/Github/Domain/Value/Search/Query.php
@@ -16,6 +16,7 @@ namespace App\Github\Domain\Value\Search;
 use App\Domain\Value\Branch;
 use App\Domain\Value\Repository;
 use App\Domain\Value\TrimmedNonEmptyString;
+use App\Github\Domain\Value\Label;
 use Webmozart\Assert\Assert;
 
 /**
@@ -42,19 +43,19 @@ final class Query
         return new self($value);
     }
 
-    public static function pullRequests(Repository $repository, Branch $branch, string $excludedAuthor): self
+    public static function pullRequests(Repository $repository, Branch $branch, Label $excludedLabel): self
     {
         return new self(
             sprintf(
-                'repo:%s type:pr is:merged base:%s -author:%s',
+                'repo:%s type:pr is:merged base:%s -label:%s',
                 $repository->toString(),
                 $branch->name(),
-                $excludedAuthor
+                $excludedLabel->name()
             )
         );
     }
 
-    public static function pullRequestsSince(Repository $repository, Branch $branch, \DateTimeImmutable $date, string $excludedAuthor): self
+    public static function pullRequestsSince(Repository $repository, Branch $branch, \DateTimeImmutable $date, Label $excludedLabel): self
     {
         return new self(
             sprintf(
@@ -62,7 +63,7 @@ final class Query
                 $repository->toString(),
                 $branch->name(),
                 $date->format('Y-m-d\TH:i:s\Z'), // @todo check if there is a better way to format the datetime like this
-                $excludedAuthor
+                $excludedLabel->name()
             )
         );
     }

--- a/tests/Github/Domain/Value/Search/QueryTest.php
+++ b/tests/Github/Domain/Value/Search/QueryTest.php
@@ -15,6 +15,7 @@ namespace App\Tests\Github\Domain\Value\Search;
 
 use App\Domain\Value\Branch;
 use App\Domain\Value\Repository;
+use App\Github\Domain\Value\Label;
 use App\Github\Domain\Value\Search\Query;
 use Ergebnis\Test\Util\Helper;
 use Packagist\Api\Result\Package;
@@ -86,7 +87,7 @@ final class QueryTest extends TestCase
         $query = Query::pullRequests(
             $repository,
             $branch,
-            'SonataCI'
+            Label::DevKit()
         );
 
         static::assertSame(
@@ -132,7 +133,7 @@ final class QueryTest extends TestCase
             $repository,
             $branch,
             new \DateTimeImmutable('2020-01-01 10:00:00'),
-            'SonataCI'
+            Label::DevKit()
         );
 
         static::assertSame(

--- a/tests/Github/Domain/Value/Search/QueryTest.php
+++ b/tests/Github/Domain/Value/Search/QueryTest.php
@@ -91,7 +91,7 @@ final class QueryTest extends TestCase
         );
 
         static::assertSame(
-            'repo:sonata-project/SonataAdminBundle type:pr is:merged base:master -author:SonataCI',
+            'repo:sonata-project/SonataAdminBundle type:pr is:merged base:master -label:dev-kit',
             $query->toString()
         );
     }
@@ -137,7 +137,7 @@ final class QueryTest extends TestCase
         );
 
         static::assertSame(
-            'repo:sonata-project/SonataAdminBundle type:pr is:merged base:master merged:>2020-01-01T10:00:00Z -author:SonataCI',
+            'repo:sonata-project/SonataAdminBundle type:pr is:merged base:master merged:>2020-01-01T10:00:00Z -label:dev-kit',
             $query->toString()
         );
     }


### PR DESCRIPTION
With this labels, when we need to add changelog to a dev-kit PR, we can remove the labels and go with it, it will generate changelog on the release command.