### PR TITLE
Add Symfony 6.3 build

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,10 +26,8 @@ jobs:
                   coverage: none
                   tools: composer:v2
 
-            - name: Install Composer dependencies (${{ matrix.dependencies }})
+            - name: Install Composer dependencies (locked)
               uses: ramsey/composer-install@v2
-              with:
-                  dependency-versions: ${{ matrix.dependencies }}
 
             - name: Lint PHP files
               run: make lint-php

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -5,12 +5,12 @@ admin-bundle:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         4.x:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
                 sonata-project/block-bundle: ['5.x-dev as 4.999']
                 sonata-project/form-extensions: ['2.x-dev as 1.999']
 
@@ -19,11 +19,11 @@ block-bundle:
         5.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         4.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['4.4.*', '5.4.*', '6.2.*']
+                symfony/symfony: ['4.4.*', '5.4.*', '6.2.*', '6.3.*']
 
 classification-bundle:
     branches:
@@ -31,12 +31,12 @@ classification-bundle:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         4.x:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 doctrine-extensions:
     has_documentation: false
@@ -55,12 +55,12 @@ doctrine-mongodb-admin-bundle:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         4.x:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 doctrine-orm-admin-bundle:
     documentation_badge_slug: sonata-project-doctrineormadminbundle
@@ -69,11 +69,11 @@ doctrine-orm-admin-bundle:
         5.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         4.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 entity-audit-bundle:
     excluded_files:
@@ -85,11 +85,11 @@ entity-audit-bundle:
         2.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         1.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 exporter:
     documentation_badge_slug: sonata-project-exporter
@@ -99,23 +99,23 @@ exporter:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         3.x:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 formatter-bundle:
     branches:
         6.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         5.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 form-extensions:
     has_test_kernel: false
@@ -124,12 +124,12 @@ form-extensions:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         1.x:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
-                symfony/symfony: ['4.4.*', '5.4.*', '6.2.*']
+                symfony/symfony: ['4.4.*', '5.4.*', '6.2.*', '6.3.*']
 
 intl-bundle:
     has_test_kernel: false
@@ -137,11 +137,11 @@ intl-bundle:
         4.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         3.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 media-bundle:
     documentation_badge_slug: sonata-project-sonatamediabundle
@@ -150,12 +150,12 @@ media-bundle:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb', 'gd']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         4.x:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb', 'gd']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 page-bundle:
     branches:
@@ -163,13 +163,13 @@ page-bundle:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
                 sonata-project/block-bundle: ['5.x-dev as 4.999']
         4.x:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
                 sonata-project/block-bundle: ['5.x-dev as 4.999']
 
 seo-bundle:
@@ -178,22 +178,22 @@ seo-bundle:
         4.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         3.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 translation-bundle:
     branches:
         4.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         3.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 twig-extensions:
     documentation_badge_slug: sonata-project-twig-extensions
@@ -201,11 +201,11 @@ twig-extensions:
         3.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         2.x:
             php: ['8.0', '8.1', '8.2']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
 
 user-bundle:
     branches:
@@ -213,9 +213,9 @@ user-bundle:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
         5.x:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.2.*']
+                symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']

--- a/templates/project/.github/workflows/lint.yaml.twig
+++ b/templates/project/.github/workflows/lint.yaml.twig
@@ -41,7 +41,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Lint PHP files
               run: make lint-php

--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -41,7 +41,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: PHPStan
               run: vendor/bin/phpstan --no-progress --memory-limit=1G analyse --error-format=github
@@ -69,7 +68,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Psalm
               run: vendor/bin/psalm --no-progress --show-info=false --stats --output-format=github --threads=$(nproc) --shepherd --php-version={{ branch.targetPhpVersion.toString }}
@@ -97,7 +95,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Rector
               run: vendor/bin/rector --no-progress-bar --dry-run

--- a/templates/project/.github/workflows/symfony-lint.yaml.twig
+++ b/templates/project/.github/workflows/symfony-lint.yaml.twig
@@ -38,7 +38,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Lint container
               run: make lint-symfony-container
@@ -63,7 +62,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Lint twig files
               run: make lint-symfony-twig
@@ -88,7 +86,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Lint xliff files
               run: make lint-symfony-xliff
@@ -113,7 +110,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Lint yaml files
               run: make lint-symfony-yaml

--- a/templates/project/.github/workflows/test-platforms.yaml.twig
+++ b/templates/project/.github/workflows/test-platforms.yaml.twig
@@ -64,7 +64,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: {% verbatim %}${{ matrix.dependencies }}{% endverbatim %}
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Run Tests
               run: make test
@@ -118,7 +117,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: {% verbatim %}${{ matrix.dependencies }}{% endverbatim %}
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Run Tests
               run: make test

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -96,7 +96,6 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: {% verbatim %}${{ matrix.dependencies }}{% endverbatim %}
-                  composer-options: --prefer-dist --prefer-stable
 
             - name: Run Tests with coverage
               run: make coverage

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -186,7 +186,6 @@ final class DispatchFilesCommandTest extends TestCase
                           uses: ramsey/composer-install@v2
                           with:
                               dependency-versions: ${{ matrix.dependencies }}
-                              composer-options: --prefer-dist --prefer-stable
 
                         - name: Run Tests with coverage
                           run: make coverage


### PR DESCRIPTION
It will require to update all composer.json projects to include prefer-stable = true and minimum-stability = dev

I think it will be good to do this change, not only for sf 6.3, but also thinking on 6.4, that we want to test way before it comes out. (in preparation for 7.0)