### PR TITLE
Allow mixed on php-cs-fixer

### DIFF
--- a/templates/project/.php-cs-fixer.dist.php
+++ b/templates/project/.php-cs-fixer.dist.php
@@ -42,6 +42,7 @@ $rules = [
     'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
     'no_useless_else' => true,
     'no_useless_return' => true,
+    'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
     'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => true],
     'ordered_class_elements' => true,
     'ordered_imports' => ['sort_algorithm' => 'alpha', 'imports_order' => ['class', 'function', 'const']],


### PR DESCRIPTION
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6987

We use mixed a lot and recently got changed. If we remove those mixed, phpstan and psalm starts complaining (specially phpstan)