### PR TITLE
remove block-bundle 5.0.0-alpha-1 variants

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -6,13 +6,11 @@ admin-bundle:
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
         4.x:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
 
 block-bundle:
     branches:
@@ -32,13 +30,11 @@ classification-bundle:
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
         4.x:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
 
 doctrine-extensions:
     has_documentation: false
@@ -114,12 +110,10 @@ formatter-bundle:
             php: ['8.0', '8.1', '8.2']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
         5.x:
             php: ['8.0', '8.1', '8.2']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
 
 form-extensions:
     has_test_kernel: false
@@ -157,13 +151,11 @@ media-bundle:
             php_extensions: ['mongodb', 'gd']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
         4.x:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb', 'gd']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
 
 page-bundle:
     branches:
@@ -172,13 +164,11 @@ page-bundle:
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
         4.x:
             php: ['8.0', '8.1', '8.2']
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
 
 seo-bundle:
     has_test_kernel: false
@@ -187,12 +177,10 @@ seo-bundle:
             php: ['8.0', '8.1', '8.2']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
         3.x:
             php: ['8.0', '8.1', '8.2']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
 
 translation-bundle:
     branches:
@@ -200,12 +188,10 @@ translation-bundle:
             php: ['8.0', '8.1', '8.2']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
         3.x:
             php: ['8.0', '8.1', '8.2']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
 
 twig-extensions:
     documentation_badge_slug: sonata-project-twig-extensions
@@ -226,10 +212,8 @@ user-bundle:
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']
         5.x:
             php: ['8.0', '8.1', '8.2']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.2.*', '6.3.*']
-                sonata-project/block-bundle: ['5.0.0-alpha-1']


### PR DESCRIPTION
Not needed anymore, right? 5.0.0 was released.