### PR TITLE
Add Symfony 7 to SonataDoctrineMongoDBBundle

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -49,7 +49,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/dispatch-files-branches.yaml
+++ b/.github/workflows/dispatch-files-branches.yaml
@@ -49,7 +49,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/dispatch-labels-hooks-topics-settings.yaml
+++ b/.github/workflows/dispatch-labels-hooks-topics-settings.yaml
@@ -46,7 +46,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set up Python 3.11
               uses: actions/setup-python@v5
@@ -42,7 +42,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Run DOCtor-RST
               uses: docker://oskarstark/doctor-rst

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -39,7 +39,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -60,7 +60,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install yamllint
               run: sudo apt-get install yamllint
@@ -75,7 +75,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install required dependencies
               run: sudo apt-get update && sudo apt-get install libxml2-utils

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -39,7 +39,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -61,7 +61,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -57,7 +57,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -53,12 +53,12 @@ doctrine-mongodb-admin-bundle:
             php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
+                symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         4.x:
             php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
+                symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
 
 doctrine-orm-admin-bundle:
     documentation_badge_slug: sonata-project-doctrineormadminbundle

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -2,12 +2,12 @@ admin-bundle:
     documentation_badge_slug: sonata-project-sonataadminbundle
     branches:
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
@@ -15,23 +15,23 @@ admin-bundle:
 block-bundle:
     branches:
         6.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
 
 classification-bundle:
     branches:
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
@@ -41,21 +41,21 @@ doctrine-extensions:
     has_test_kernel: false
     branches:
         3.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
         2.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
 
 doctrine-mongodb-admin-bundle:
     branches:
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
@@ -65,11 +65,11 @@ doctrine-orm-admin-bundle:
     has_platform_tests: true
     branches:
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
 
@@ -81,11 +81,11 @@ entity-audit-bundle:
     has_platform_tests: true
     branches:
         2.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         1.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
 
@@ -94,12 +94,12 @@ exporter:
     has_test_kernel: false
     branches:
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         3.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
@@ -107,11 +107,11 @@ exporter:
 formatter-bundle:
     branches:
         6.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
 
@@ -119,13 +119,13 @@ form-extensions:
     has_test_kernel: false
     branches:
         3.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             frontend: true
             frontend_tests: true
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         2.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             frontend: true
             frontend_tests: true
             variants:
@@ -135,11 +135,11 @@ intl-bundle:
     has_test_kernel: false
     branches:
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         3.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
 
@@ -147,12 +147,12 @@ media-bundle:
     documentation_badge_slug: sonata-project-sonatamediabundle
     branches:
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb', 'gd']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb', 'gd']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
@@ -160,12 +160,12 @@ media-bundle:
 page-bundle:
     branches:
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             frontend: true
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
@@ -174,22 +174,22 @@ seo-bundle:
     has_test_kernel: false
     branches:
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         3.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
 
 translation-bundle:
     branches:
         4.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
         3.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
 
@@ -197,23 +197,23 @@ twig-extensions:
     documentation_badge_slug: sonata-project-twig-extensions
     branches:
         3.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
         2.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
 
 user-bundle:
     branches:
         6.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']
         5.x:
-            php: ['8.0', '8.1', '8.2']
+            php: ['8.0', '8.1', '8.2', '8.3']
             php_extensions: ['mongodb']
             variants:
                 symfony/symfony: ['5.4.*', '6.3.*', '6.4.*']

--- a/templates/project/.github/workflows/documentation.yaml.twig
+++ b/templates/project/.github/workflows/documentation.yaml.twig
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set up Python 3.11
               uses: actions/setup-python@v4
@@ -46,7 +46,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Run DOCtor-RST
               uses: docker://oskarstark/doctor-rst

--- a/templates/project/.github/workflows/frontend.yaml.twig
+++ b/templates/project/.github/workflows/frontend.yaml.twig
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install Node
               uses: actions/setup-node@v3
@@ -58,7 +58,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install Node
               uses: actions/setup-node@v3

--- a/templates/project/.github/workflows/lint.yaml.twig
+++ b/templates/project/.github/workflows/lint.yaml.twig
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -52,7 +52,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -73,7 +73,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install yamllint
               run: sudo apt-get install yamllint
@@ -88,7 +88,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install required dependencies
               run: sudo apt-get update && sudo apt-get install libxml2-utils

--- a/templates/project/.github/workflows/qa.yaml.twig
+++ b/templates/project/.github/workflows/qa.yaml.twig
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -52,7 +52,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -79,7 +79,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/templates/project/.github/workflows/symfony-lint.yaml.twig
+++ b/templates/project/.github/workflows/symfony-lint.yaml.twig
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -49,7 +49,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -73,7 +73,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -97,7 +97,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/templates/project/.github/workflows/test-platforms.yaml.twig
+++ b/templates/project/.github/workflows/test-platforms.yaml.twig
@@ -47,7 +47,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -101,7 +101,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -67,7 +67,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -74,19 +74,13 @@ jobs:
               with:
                   php-version: {% verbatim %}${{ matrix.php-version }}{% endverbatim %}
                   coverage: pcov
-                  tools: composer:v2
+                  tools: composer:v2, flex
 {% if branch.phpExtensions is not empty %}
                   extensions: {{ branch.phpExtensions|map(phpExtension => phpExtension.toString)|join(', ') }}
 {% endif %}
 
             - name: Add PHPUnit matcher
               run: echo "::add-matcher::{% verbatim %}${{ runner.tool_cache }}{% endverbatim %}/phpunit.json"
-
-            - name: Globally install symfony/flex
-              if: matrix.symfony-require != ''
-              run: |
-                  composer global config --no-plugins allow-plugins.symfony/flex true
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
 
             - name: Install variant
               if: matrix.variant != 'normal' && !startsWith(matrix.variant, 'symfony/symfony')

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -162,7 +162,7 @@ final class DispatchFilesCommandTest extends TestCase
 
                     steps:
                         - name: Checkout
-                          uses: actions/checkout@v3
+                          uses: actions/checkout@v4
 
                         - name: Install PHP with extensions
                           uses: shivammathur/setup-php@v2

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -169,16 +169,10 @@ final class DispatchFilesCommandTest extends TestCase
                           with:
                               php-version: ${{ matrix.php-version }}
                               coverage: pcov
-                              tools: composer:v2
+                              tools: composer:v2, flex
 
                         - name: Add PHPUnit matcher
                           run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-                        - name: Globally install symfony/flex
-                          if: matrix.symfony-require != ''
-                          run: |
-                              composer global config --no-plugins allow-plugins.symfony/flex true
-                              composer global require --no-progress --no-scripts --no-plugins symfony/flex
 
                         - name: Install variant
                           if: matrix.variant != 'normal' && !startsWith(matrix.variant, 'symfony/symfony')


### PR DESCRIPTION
POC: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/843

There some other additions:
- Use flex as a tool
- Add PHP 8.3 to CI
- Bump some actions