### PR TITLE
Disable class-methods-use-this rule

### DIFF
--- a/templates/project/.eslintrc.js
+++ b/templates/project/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   plugins: ['header'],
   rules: {
     'arrow-body-style': 'off',
+    'class-methods-use-this': 'off',
     'header/header': [
       2,
       'block',


### PR DESCRIPTION
Disable rule for PR [#8265](https://github.com/sonata-project/SonataAdminBundle/pull/8265)
I think we can disable this rule globaly