### PR TITLE
add changes for dropping PHP 8.1 and adding Symfony 8

### DIFF
--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -2,76 +2,76 @@ admin-bundle:
     documentation_badge_slug: sonata-project-sonataadminbundle
     branches:
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             frontend: true
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             frontend: true
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 block-bundle:
     branches:
         6.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 classification-bundle:
     branches:
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 doctrine-extensions:
     has_documentation: false
     has_test_kernel: false
     branches:
         3.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
         2.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
 
 doctrine-mongodb-admin-bundle:
     branches:
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 doctrine-orm-admin-bundle:
     documentation_badge_slug: sonata-project-doctrineormadminbundle
     has_platform_tests: true
     branches:
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 entity-audit-bundle:
     excluded_files:
@@ -81,139 +81,139 @@ entity-audit-bundle:
     has_platform_tests: true
     branches:
         2.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         1.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 exporter:
     documentation_badge_slug: sonata-project-exporter
     has_test_kernel: false
     branches:
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         3.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 formatter-bundle:
     branches:
         6.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 form-extensions:
     has_test_kernel: false
     branches:
         3.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             frontend: true
             frontend_tests: true
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         2.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             frontend: true
             frontend_tests: true
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 intl-bundle:
     has_test_kernel: false
     branches:
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         3.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 media-bundle:
     documentation_badge_slug: sonata-project-sonatamediabundle
     branches:
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb', 'gd']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb', 'gd']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 page-bundle:
     branches:
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             frontend: true
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             frontend: true
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 seo-bundle:
     has_test_kernel: false
     branches:
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         3.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 translation-bundle:
     branches:
         4.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         3.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 twig-extensions:
     documentation_badge_slug: sonata-project-twig-extensions
     branches:
         3.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         2.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
 
 user-bundle:
     branches:
         6.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         5.x:
-            php: ['8.1', '8.2', '8.3', '8.4']
+            php: ['8.2', '8.3', '8.4', '8.5']
             php_extensions: ['mongodb']
             variants:
-                symfony/symfony: ['6.4.*', '7.1.*', '7.2.*']
+                symfony/symfony: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']

--- a/templates/project/.github/workflows/test.yaml.twig
+++ b/templates/project/.github/workflows/test.yaml.twig
@@ -82,6 +82,11 @@ jobs:
             - name: Add PHPUnit matcher
               run: echo "::add-matcher::{% verbatim %}${{ runner.tool_cache }}{% endverbatim %}/phpunit.json"
 
+            # until Psalm supports Symfony 8
+            - name: Remove psalm
+              if: matrix.symfony-require == '8.0.*'
+              run: composer remove vimeo/psalm psalm/plugin-symfony psalm/plugin-phpunit --dev --no-update
+
             - name: Install variant
               if: matrix.variant != 'normal' && !startsWith(matrix.variant, 'symfony/symfony')
               run: composer require {% verbatim %}${{ matrix.variant }}{% endverbatim %} --no-update

--- a/templates/project/.gitignore.twig
+++ b/templates/project/.gitignore.twig
@@ -10,6 +10,7 @@ composer.lock
 phpunit.xml
 phpstan.neon
 /.phpunit.result.cache
+tests/App/config/reference.php
 {% if project.hasDocumentation %}
 /docs/_build/
 {% endif %}

--- a/tests/Command/Dispatcher/DispatchFilesCommandTest.php
+++ b/tests/Command/Dispatcher/DispatchFilesCommandTest.php
@@ -173,6 +173,11 @@ final class DispatchFilesCommandTest extends TestCase
                         - name: Add PHPUnit matcher
                           run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+                        # until Psalm supports Symfony 8
+                        - name: Remove psalm
+                          if: matrix.symfony-require == '8.0.*'
+                          run: composer remove vimeo/psalm psalm/plugin-symfony psalm/plugin-phpunit --dev --no-update
+
                         - name: Install variant
                           if: matrix.variant != 'normal' && !startsWith(matrix.variant, 'symfony/symfony')
                           run: composer require ${{ matrix.variant }} --no-update


### PR DESCRIPTION
As discussed in #2962 

This
- drops PHP 8.1
- adds PHP 8.5
- drops Symfony 7.1 and 7.2
- adds Symfony 7.4 and 8.0

I tested it on https://github.com/sonata-project/twig-extensions/pull/431